### PR TITLE
Added support of extracting email out of SAML response subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ In config/initializers/devise.rb
     # Create user if the user does not exist. (Default is false)
     config.saml_create_user = true
     
-    # Set the default user key (default is email). The user will be looked up by this key. Make sure that the Authentication Response includes
-    # the attribute
+    # Set the default user key (default is email). The user will be looked up by this key. 
     config.saml_default_user_key = :email
+	
+	# You can set this value to use Subject or SAML assertation as info to which email will be compared
+	# If you don't set it then email will be extracted from SAML assertation attributes
+	config.saml_use_subject = true
   end
 ```
 

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -30,6 +30,9 @@ module Devise
   
   mattr_accessor :saml_default_user_key
   @@saml_default_user_key
+  
+  mattr_accessor :saml_use_subject
+  @@saml_use_subject
 end
 
 # Add saml_authenticatable strategy to defaults.

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -43,11 +43,11 @@ module Devise
           end
 
 	        if (resource.nil? && Devise.saml_create_user)
-            logger.info("Creating user(#{attributes[inv_attr[key.to_s]]}).")
 	          resource = new
-            if (Device.saml_use_subject)
-              resource.send "#{key}", auth_value
+            if (Devise.saml_use_subject)
+              resource.send "#{key}=", auth_value
             else
+              logger.info("Creating user(#{attributes[inv_attr[key.to_s]]}).")              
               set_user_saml_attributes(resource,attributes)
             end
             resource.save!

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -9,7 +9,7 @@ module Devise
       def authenticate!
         @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse])
 	      @response.settings = get_saml_config
-	      resource = mapping.to.authenticate_with_saml(@response.attributes)
+	      resource = mapping.to.authenticate_with_saml(@response)
         if @response.is_valid?
           success!(resource)
         else


### PR DESCRIPTION
The idea of this pull request is to be able to extract from SAML reposnse a subject and treat it as an attribute (this is for a case, when SAML Provider doesn't send along attributes).