### PR TITLE
Skip CSRF from IdP

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -4,6 +4,8 @@ class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
   unloadable if Rails::VERSION::MAJOR < 4
   before_filter :get_saml_config
+  skip_before_filter :verify_authenticity_token
+
   def new
     request = OneLogin::RubySaml::Authrequest.new
     action = request.create(@saml_config)


### PR DESCRIPTION
The IdP does not include an authenticity token in its POST request, so the SAML controller should not verify it.