### PR TITLE
Allow SAML configuration via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,40 +43,37 @@ In config/initializers/devise.rb
     # Set the default user key. The user will be looked up by this key. Make
     # sure that the Authentication Response includes the attribute.
     config.saml_default_user_key = :email
+
+    # Configure with your SAML settings (see [ruby-saml][] for more information).
+    config.saml_configure do |settings|
+      settings.assertion_consumer_service_url     = "http://localhost:3000/users/sign_in"
+      settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+      settings.name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+      settings.issuer                             = "http://localhost:3000"
+      settings.authn_context                      = ""
+      settings.idp_sso_target_url                 = "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
+      settings.idp_cert                           = <<-CERT.chomp
+-----BEGIN CERTIFICATE-----
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111_______IDP_CERTIFICATE________111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+111111111111111111
+-----END CERTIFICATE-----
+      CERT
+    end
   end
 ```
 
-In config directory, create a YAML file (`idp.yml`) with your SAML settings (see [ruby-saml][] for more information). For example
-
-```yaml
-  # idp.yaml
-  development:
-    idp_metadata: ""
-    idp_metadata_ttl: ""
-    assertion_consumer_service_url: "http://localhost:3000/users/sign_in"
-    assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-    name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-    issuer: "http://localhost:3000"
-    authn_context: ""
-    idp_sso_target_url: "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
-    idp_cert: |-
-      -----BEGIN CERTIFICATE-----
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111_______IDP_CERTIFICATE________111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      111111111111111111
-      -----END CERTIFICATE-----
-```    
 In config directory create a YAML file (`attribute-map.yml`) that maps SAML attributes with your model's fields:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DeviseSamlAuthenticatable
 
-Devise Saml Authenticatable is a Single-Sign-On authentication strategy for devise that relies on SAML. It uses [ruby-saml](https://github.com/onelogin/ruby-saml) to handle all SAML related stuff.
+Devise Saml Authenticatable is a Single-Sign-On authentication strategy for devise that relies on SAML.
+It uses [ruby-saml][] to handle all SAML related stuff.
 
 ## Installation
 
@@ -18,7 +19,8 @@ Or install it yourself as:
 
 ## Usage
 
-In app/models/<YOUR_MODEL>.rb set the :saml_authenticatable strategy. In the example the model is user.rb
+In `app/models/<YOUR_MODEL>.rb` set the `:saml_authenticatable` strategy.
+In the example the model is `user.rb`:
 
 ```ruby
   class User < ActiveRecord::Base
@@ -33,20 +35,20 @@ In config/initializers/devise.rb
 ```ruby
   Devise.setup do |config|
     ...
-    # ==> DeviseSamlAuthenticatable Configuration
+    # ==> Configuration for :saml_authenticatable
     
     # Create user if the user does not exist. (Default is false)
     config.saml_create_user = true
     
-    # Set the default user key (default is email). The user will be looked up by this key. Make sure that the Authentication Response includes
-    # the attribute
+    # Set the default user key. The user will be looked up by this key. Make
+    # sure that the Authentication Response includes the attribute.
     config.saml_default_user_key = :email
   end
 ```
 
-In config directory, create a YAML file (idp.yml) with your SAML settings (see ruby-saml for more information). For example
+In config directory, create a YAML file (`idp.yml`) with your SAML settings (see [ruby-saml][] for more information). For example
 
-```ruby
+```yaml
   # idp.yaml
   development:
     idp_metadata: ""
@@ -75,9 +77,9 @@ In config directory, create a YAML file (idp.yml) with your SAML settings (see r
       111111111111111111
       -----END CERTIFICATE-----
 ```    
-In config directory create a YAML file (attribute-map.yml) that maps SAML attributes with your model's fields
+In config directory create a YAML file (`attribute-map.yml`) that maps SAML attributes with your model's fields:
 
-```ruby
+```yaml
   # attribute-map.yml
   
   "urn:mace:dir:attribute-def:uid": "user_name"
@@ -86,18 +88,19 @@ In config directory create a YAML file (attribute-map.yml) that maps SAML attrib
   "urn:mace:dir:attribute-def:givenName": "name"
 ```
 
-The attribute mappings are very dependent on the way the IdP encodes the attributes. In this example the attributes are given in URN style. Other IdPs might provide them as OID's or other means. 
+The attribute mappings are very dependent on the way the IdP encodes the attributes.
+In this example the attributes are given in URN style.
+Other IdPs might provide them as OID's or other means.
 
-You are now ready to test it against an IdP. When the user goes to /users/saml/sign_in he will be redirected to the login page of the IdP. Upon successful login the user is redirected to devise user_root_path.
+You are now ready to test it against an IdP.
+When the user goes to `/users/saml/sign_in` he will be redirected to the login page of the IdP.
+Upon successful login the user is redirected to devise `user_root_path`.
 
 ## Identity Provider
 
 If you don't have an identity provider an you would like to test the authentication against your app there are some options:
 
-1. Use [ruby-saml-idp](https://github.com/lawrencepit/ruby-saml-idp). 
-
-You can add your own logic to your IdP, or you can also set it as a dummy IdP that always sends a valid authentication response to your app.
-
+1. Use [ruby-saml-idp](https://github.com/lawrencepit/ruby-saml-idp). You can add your own logic to your IdP, or you can also set it as a dummy IdP that always sends a valid authentication response to your app.
 2. Use an online service that can act as an IdP. Onelogin, Salesforce and some others provide you with this functionality
 3. Install your own IdP.
 
@@ -107,7 +110,7 @@ There are numerous IdPs that support SAML 2.0, there are propietary (like Micros
 
 ## Limitations
 
-1. At the moment there is no support for Single Logout (we're working on that)
+1. At the moment there is no support for Single Logout
 2. The Authentication Requests (from your app to the IdP) are not signed and encrypted
 
 ## Contributing
@@ -117,3 +120,5 @@ There are numerous IdPs that support SAML 2.0, there are propietary (like Micros
 3. Commit your changes (`git commit -am 'Added some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+[ruby-saml]: https://github.com/onelogin/ruby-saml

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -25,11 +25,14 @@ module Devise
   mattr_accessor :saml_create_user
   @@saml_create_user = false
   
-  mattr_accessor :saml_config
-  @@saml_config = "#{Rails.root}/config/saml.yml"
-  
   mattr_accessor :saml_default_user_key
   @@saml_default_user_key
+
+  mattr_accessor :saml_config
+  @@saml_config = OneLogin::RubySaml::Settings.new
+  def self.saml_configure
+    yield saml_config
+  end
 end
 
 # Add saml_authenticatable strategy to defaults.

--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -1,8 +1,15 @@
 require 'ruby-saml'
 module DeviseSamlAuthenticatable
   module SamlConfig
+    IDP_CONFIG_PATH = "#{Rails.root}/config/idp.yml"
+
     def get_saml_config
-      @saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read("#{Rails.root}/config/idp.yml"))[Rails.env])
+      # Support 0.0.x-style configuration via a YAML file
+      if File.exists?(IDP_CONFIG_PATH)
+        Devise.saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read(IDP_CONFIG_PATH))[Rails.env])
+      end
+
+      @saml_config = Devise.saml_config
     end
   end
 end


### PR DESCRIPTION
Instead of requiring `idp.yml` in the application, allow custom configuration by exposing the `RubySaml::Settings`. This is primarily for configuration via environment variables, but that's not required.

`idp.yml` is still supported to not break anyone else.