### PR TITLE
Allow SAML configuration via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,40 +47,37 @@ In config/initializers/devise.rb
     # You can set this value to use Subject or SAML assertation as info to which email will be compared
     # If you don't set it then email will be extracted from SAML assertation attributes
     config.saml_use_subject = true
+
+    # Configure with your SAML settings (see [ruby-saml][] for more information).
+    config.saml_configure do |settings|
+      settings.assertion_consumer_service_url     = "http://localhost:3000/users/sign_in"
+      settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+      settings.name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+      settings.issuer                             = "http://localhost:3000"
+      settings.authn_context                      = ""
+      settings.idp_sso_target_url                 = "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
+      settings.idp_cert                           = <<-CERT.chomp
+-----BEGIN CERTIFICATE-----
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111_______IDP_CERTIFICATE________111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111
+111111111111111111
+-----END CERTIFICATE-----
+      CERT
+    end
   end
 ```
 
-In config directory, create a YAML file (`idp.yml`) with your SAML settings (see [ruby-saml][] for more information). For example
-
-```yaml
-  # idp.yaml
-  development:
-    idp_metadata: ""
-    idp_metadata_ttl: ""
-    assertion_consumer_service_url: "http://localhost:3000/users/sign_in"
-    assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-    name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-    issuer: "http://localhost:3000"
-    authn_context: ""
-    idp_sso_target_url: "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
-    idp_cert: |-
-      -----BEGIN CERTIFICATE-----
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111_______IDP_CERTIFICATE________111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      1111111111111111111111111111111111111111111111111111111111111111
-      111111111111111111
-      -----END CERTIFICATE-----
-```    
 In config directory create a YAML file (`attribute-map.yml`) that maps SAML attributes with your model's fields:
 
 ```yaml

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -25,14 +25,17 @@ module Devise
   mattr_accessor :saml_create_user
   @@saml_create_user = false
 
-  mattr_accessor :saml_config
-  @@saml_config = "#{Rails.root}/config/saml.yml"
-
   mattr_accessor :saml_default_user_key
   @@saml_default_user_key
 
   mattr_accessor :saml_use_subject
   @@saml_use_subject
+
+  mattr_accessor :saml_config
+  @@saml_config = OneLogin::RubySaml::Settings.new
+  def self.saml_configure
+    yield saml_config
+  end
 end
 
 # Add saml_authenticatable strategy to defaults.

--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -1,12 +1,11 @@
 require 'ruby-saml'
 module DeviseSamlAuthenticatable
   module SamlConfig
-    IDP_CONFIG_PATH = "#{Rails.root}/config/idp.yml"
-
     def get_saml_config
+      idp_config_path = "#{Rails.root}/config/idp.yml"
       # Support 0.0.x-style configuration via a YAML file
-      if File.exists?(IDP_CONFIG_PATH)
-        Devise.saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read(IDP_CONFIG_PATH))[Rails.env])
+      if File.exists?(idp_config_path)
+        Devise.saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read(idp_config_path))[Rails.env])
       end
 
       @saml_config = Devise.saml_config

--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -1,8 +1,15 @@
 require 'ruby-saml'
 module DeviseSamlAuthenticatable
   module SamlConfig
+    IDP_CONFIG_PATH = "#{Rails.root}/config/idp.yml"
+
     def get_saml_config
-      @saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read("#{Rails.root}/config/idp.yml"))[Rails.env])
+      # Support 0.0.x-style configuration via a YAML file
+      if File.exists?(IDP_CONFIG_PATH)
+        Devise.saml_config = OneLogin::RubySaml::Settings.new(YAML.load(File.read(IDP_CONFIG_PATH))[Rails.env])
+      end
+
+      @saml_config = Devise.saml_config
     end
   end
 end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -8,9 +8,7 @@ require_relative '../../../app/controllers/devise/saml_sessions_controller'
 
 
 describe Devise::SamlSessionsController, type: :controller do
-  let(:saml_config) {
-    OneLogin::RubySaml::Settings.new(YAML.load_file(File.expand_path('../../../support/sp/config/idp.yml', __FILE__))[Rails.env])
-  }
+  let(:saml_config) { Devise.saml_config }
 
   describe '#new' do
     it 'redirects to the SAML Auth Request endpoint' do

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -4,6 +4,14 @@ describe DeviseSamlAuthenticatable::SamlConfig do
   subject(:saml_config) { controller.get_saml_config }
   let(:controller) { Class.new { include DeviseSamlAuthenticatable::SamlConfig }.new }
 
+  # Replace global config since this test changes it
+  before do
+    @original_saml_config = Devise.saml_config
+  end
+  after do
+    Devise.saml_config = @original_saml_config
+  end
+
   context "when config/idp.yml does not exist" do
     before do
       allow(Rails).to receive(:root).and_return("/railsroot")

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -4,10 +4,19 @@ describe DeviseSamlAuthenticatable::SamlConfig do
   subject(:saml_config) { controller.get_saml_config }
   let(:controller) { Class.new { include DeviseSamlAuthenticatable::SamlConfig }.new }
 
-  before do
-    allow(Rails).to receive(:env).and_return("environment")
-    allow(Rails).to receive(:root).and_return("/railsroot")
-    allow(File).to receive(:read).with("/railsroot/config/idp.yml").and_return(<<-IDP)
+  it "is the global devise SAML config" do
+    Devise.saml_configure do |config|
+      config.assertion_consumer_logout_service_binding = 'test'
+    end
+    expect(saml_config).to be(Devise.saml_config)
+    expect(saml_config.assertion_consumer_logout_service_binding).to eq('test')
+  end
+
+  context "when config/idp.yml exists" do
+    before do
+      allow(Rails).to receive(:env).and_return("environment")
+      allow(File).to receive(:exists?).with("/config/idp.yml").and_return(true)
+      allow(File).to receive(:read).with("/config/idp.yml").and_return(<<-IDP)
 ---
 environment:
   assertion_consumer_logout_service_binding: assertion_consumer_logout_service_binding
@@ -39,36 +48,37 @@ environment:
   sessionindex: sessionindex
   sp_name_qualifier: sp_name_qualifier
       IDP
-  end
+    end
 
-  it "stores the configured IdP settings" do
-    expect(saml_config.assertion_consumer_logout_service_binding).to eq('assertion_consumer_logout_service_binding')
-    expect(saml_config.assertion_consumer_logout_service_url).to eq('assertion_consumer_logout_service_url')
-    expect(saml_config.assertion_consumer_service_binding).to eq('assertion_consumer_service_binding')
-    expect(saml_config.assertion_consumer_service_url).to eq('assertion_consumer_service_url')
-    expect(saml_config.attributes_index).to eq('attributes_index')
-    expect(saml_config.authn_context).to eq('authn_context')
-    expect(saml_config.authn_context_comparison).to eq('authn_context_comparison')
-    expect(saml_config.authn_context_decl_ref).to eq('authn_context_decl_ref')
-    expect(saml_config.certificate).to eq('certificate')
-    expect(saml_config.compress_request).to eq('compress_request')
-    expect(saml_config.compress_response).to eq('compress_response')
-    expect(saml_config.double_quote_xml_attribute_values).to eq('double_quote_xml_attribute_values')
-    expect(saml_config.force_authn).to eq('force_authn')
-    expect(saml_config.idp_cert).to eq('idp_cert')
-    expect(saml_config.idp_cert_fingerprint).to eq('idp_cert_fingerprint')
-    expect(saml_config.idp_cert_fingerprint_algorithm).to eq('idp_cert_fingerprint_algorithm')
-    expect(saml_config.idp_entity_id).to eq('idp_entity_id')
-    expect(saml_config.idp_slo_target_url).to eq('idp_slo_target_url')
-    expect(saml_config.idp_sso_target_url).to eq('idp_sso_target_url')
-    expect(saml_config.issuer).to eq('issuer')
-    expect(saml_config.name_identifier_format).to eq('name_identifier_format')
-    expect(saml_config.name_identifier_value).to eq('name_identifier_value')
-    expect(saml_config.passive).to eq('passive')
-    expect(saml_config.private_key).to eq('private_key')
-    expect(saml_config.protocol_binding).to eq('protocol_binding')
-    expect(saml_config.security).to eq('security')
-    expect(saml_config.sessionindex).to eq('sessionindex')
-    expect(saml_config.sp_name_qualifier).to eq('sp_name_qualifier')
+    it "stores the configured IdP settings" do
+      expect(saml_config.assertion_consumer_logout_service_binding).to eq('assertion_consumer_logout_service_binding')
+      expect(saml_config.assertion_consumer_logout_service_url).to eq('assertion_consumer_logout_service_url')
+      expect(saml_config.assertion_consumer_service_binding).to eq('assertion_consumer_service_binding')
+      expect(saml_config.assertion_consumer_service_url).to eq('assertion_consumer_service_url')
+      expect(saml_config.attributes_index).to eq('attributes_index')
+      expect(saml_config.authn_context).to eq('authn_context')
+      expect(saml_config.authn_context_comparison).to eq('authn_context_comparison')
+      expect(saml_config.authn_context_decl_ref).to eq('authn_context_decl_ref')
+      expect(saml_config.certificate).to eq('certificate')
+      expect(saml_config.compress_request).to eq('compress_request')
+      expect(saml_config.compress_response).to eq('compress_response')
+      expect(saml_config.double_quote_xml_attribute_values).to eq('double_quote_xml_attribute_values')
+      expect(saml_config.force_authn).to eq('force_authn')
+      expect(saml_config.idp_cert).to eq('idp_cert')
+      expect(saml_config.idp_cert_fingerprint).to eq('idp_cert_fingerprint')
+      expect(saml_config.idp_cert_fingerprint_algorithm).to eq('idp_cert_fingerprint_algorithm')
+      expect(saml_config.idp_entity_id).to eq('idp_entity_id')
+      expect(saml_config.idp_slo_target_url).to eq('idp_slo_target_url')
+      expect(saml_config.idp_sso_target_url).to eq('idp_sso_target_url')
+      expect(saml_config.issuer).to eq('issuer')
+      expect(saml_config.name_identifier_format).to eq('name_identifier_format')
+      expect(saml_config.name_identifier_value).to eq('name_identifier_value')
+      expect(saml_config.passive).to eq('passive')
+      expect(saml_config.private_key).to eq('private_key')
+      expect(saml_config.protocol_binding).to eq('protocol_binding')
+      expect(saml_config.security).to eq('security')
+      expect(saml_config.sessionindex).to eq('sessionindex')
+      expect(saml_config.sp_name_qualifier).to eq('sp_name_qualifier')
+    end
   end
 end

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -4,19 +4,27 @@ describe DeviseSamlAuthenticatable::SamlConfig do
   subject(:saml_config) { controller.get_saml_config }
   let(:controller) { Class.new { include DeviseSamlAuthenticatable::SamlConfig }.new }
 
-  it "is the global devise SAML config" do
-    Devise.saml_configure do |config|
-      config.assertion_consumer_logout_service_binding = 'test'
+  context "when config/idp.yml does not exist" do
+    before do
+      allow(Rails).to receive(:root).and_return("/railsroot")
+      allow(File).to receive(:exists?).with("/railsroot/config/idp.yml").and_return(false)
     end
-    expect(saml_config).to be(Devise.saml_config)
-    expect(saml_config.assertion_consumer_logout_service_binding).to eq('test')
+
+    it "is the global devise SAML config" do
+      Devise.saml_configure do |settings|
+        settings.assertion_consumer_logout_service_binding = 'test'
+      end
+      expect(saml_config).to be(Devise.saml_config)
+      expect(saml_config.assertion_consumer_logout_service_binding).to eq('test')
+    end
   end
 
   context "when config/idp.yml exists" do
     before do
       allow(Rails).to receive(:env).and_return("environment")
-      allow(File).to receive(:exists?).with("/config/idp.yml").and_return(true)
-      allow(File).to receive(:read).with("/config/idp.yml").and_return(<<-IDP)
+      allow(Rails).to receive(:root).and_return("/railsroot")
+      allow(File).to receive(:exists?).with("/railsroot/config/idp.yml").and_return(true)
+      allow(File).to receive(:read).with("/railsroot/config/idp.yml").and_return(<<-IDP)
 ---
 environment:
   assertion_consumer_logout_service_binding: assertion_consumer_logout_service_binding

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -2,18 +2,6 @@
 
 gem 'devise_saml_authenticatable', path: '../../..'
 
-create_file 'config/idp.yml', <<-IDP
----
-development: &development
-  assertion_consumer_service_url: http://localhost:8020/users/saml/auth
-  issuer: http://localhost:8020/saml/metadata
-  idp_sso_target_url: http://localhost:8009/saml/auth
-  idp_cert_fingerprint: "9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D"
-
-test:
-  <<: *development
-IDP
-
 create_file 'config/attribute-map.yml', <<-ATTRIBUTES
 ---
 "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": email
@@ -32,6 +20,13 @@ after_bundle do
   generate 'devise:install'
   gsub_file 'config/initializers/devise.rb', /^end$/, <<-CONFIG
   config.saml_default_user_key = :email
+
+  config.saml_configure do |settings|
+    settings.assertion_consumer_service_url = "http://localhost:8020/users/saml/auth"
+    settings.issuer = "http://localhost:8020/saml/metadata"
+    settings.idp_sso_target_url = "http://localhost:8009/saml/auth"
+    settings.idp_cert_fingerprint = "9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D"
+  end
 end
   CONFIG
 


### PR DESCRIPTION
Instead of requiring `idp.yml` in the application, allow custom configuration by exposing the `RubySaml::Settings`. This is primarily for configuration via environment variables, but that's not required.

`idp.yml` is still supported to not break anyone else.

Replaces #13.