### PR TITLE
Allow customized attribute_map for different environments

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -60,7 +60,7 @@ module Devise
         end
 
         def attribute_map
-          @attribute_map ||= YAML.load(File.read("#{Rails.root}/config/attribute-map.yml"))
+          @attribute_map ||= attribute_map_for_environment
         end
 
         private
@@ -69,6 +69,15 @@ module Devise
           attribute_map.each do |k,v|
             Rails.logger.info "Setting: #{v}, #{attributes[k]}"
             user.send "#{v}=", attributes[k]
+          end
+        end
+
+        def attribute_map_for_environment
+          attribute_map = YAML.load(File.read("#{Rails.root}/config/attribute-map.yml"))
+          if attribute_map.has_key?(Rails.env)
+            attribute_map[Rails.env]
+          else
+            attribute_map
           end
         end
       end


### PR DESCRIPTION
I needed a way to use a different set of attribute mappings between development and production.  This modification allows the attribute_map.yml file to have a top-level "development" or "production" key, similar to the current idp.yml file behavior.  If no such key is found, it falls back to the current behavior, so this should not affect existing implementations.