### PR TITLE
SLO Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,32 +114,6 @@ There are numerous IdPs that support SAML 2.0, there are propietary (like Micros
 ## Logout
 
 Logout support is included by immediately terminating the local session and then redirecting to the IdP.
-If, instead, you want to handle the logout response from the IdP yourself (in case of errors like a partial logout of other session participants), you can add a route to the configuration like so:
-
-```ruby
-    config.saml_configure do |settings|
-      # ...
-      settings.assertion_consumer_logout_service_url = "http://localhost:3000/users/sign_out"
-    end
-```
-
-Then in `/users/sign_out` you can parse the logout response and verify it against the request id:
-
-```ruby
-class UsersController < ApplicationController
-  # ...
-  def sign_out
-    # The logout request id is stored in the warden session for the current scope
-    logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], Devise.saml_config, matches_request_id: warden.session(:user)[:logout_request_id])
-    if logout_response.validate
-      sign_out :user
-      redirect_to root_path
-    end
-
-    # render error page
-  end
-end
-```
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ In config/initializers/devise.rb
       settings.name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
       settings.issuer                             = "http://localhost:3000"
       settings.authn_context                      = ""
+      settings.idp_slo_target_url                 = "http://localhost/simplesaml/www/saml2/idp/SingleLogoutService.php"
       settings.idp_sso_target_url                 = "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
       settings.idp_cert                           = <<-CERT.chomp
 -----BEGIN CERTIFICATE-----
@@ -112,8 +113,7 @@ There are numerous IdPs that support SAML 2.0, there are propietary (like Micros
 
 ## Limitations
 
-1. At the moment there is no support for Single Logout
-2. The Authentication Requests (from your app to the IdP) are not signed and encrypted
+1. The Authentication Requests (from your app to the IdP) are not signed and encrypted
 
 ## Thanks
 

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -21,6 +21,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
     if @saml_config.assertion_consumer_logout_service_url
       # Assume the SP is handling sign out at their logout ACS URL
       warden.session(resource_name)[:logout_request_id] = logout_request.uuid
+      # Respond just like `super`, but without signing out
       respond_to do |format|
         format.all { head :no_content }
         format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
@@ -36,6 +37,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
     @request ||= OneLogin::RubySaml::Logoutrequest.new
   end
 
+  # Override devise to send user to IdP logout for SLO
   def after_sign_out_path_for(_)
     logout_request.create(@saml_config)
   end

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -19,6 +19,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
 
   protected
 
+  # Override devise to send user to IdP logout for SLO
   def after_sign_out_path_for(_)
     request = OneLogin::RubySaml::Logoutrequest.new
     request.create(@saml_config)

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -16,6 +16,12 @@ class Devise::SamlSessionsController < Devise::SessionsController
     meta = OneLogin::RubySaml::Metadata.new
     render :xml => meta.generate(@saml_config)
   end
-  
+
+  protected
+
+  def after_sign_out_path_for(_)
+    request = OneLogin::RubySaml::Logoutrequest.new
+    request.create(@saml_config)
+  end
 end
 

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -17,29 +17,11 @@ class Devise::SamlSessionsController < Devise::SessionsController
     render :xml => meta.generate(@saml_config)
   end
 
-  def destroy
-    if @saml_config.assertion_consumer_logout_service_url
-      # Assume the SP is handling sign out at their logout ACS URL
-      warden.session(resource_name)[:logout_request_id] = logout_request.uuid
-      # Respond just like `super`, but without signing out
-      respond_to do |format|
-        format.all { head :no_content }
-        format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
-      end
-    else
-      super
-    end
-  end
-
   protected
 
-  def logout_request
-    @request ||= OneLogin::RubySaml::Logoutrequest.new
-  end
-
-  # Override devise to send user to IdP logout for SLO
   def after_sign_out_path_for(_)
-    logout_request.create(@saml_config)
+    request = OneLogin::RubySaml::Logoutrequest.new
+    request.create(@saml_config)
   end
 end
 

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -1,13 +1,10 @@
 require 'rails_helper'
 
 class Devise::SessionsController < ActionController::Base
-  # Copied from devise with unnecessary parts elided
+  # The important parts from devise
   def destroy
     sign_out
-    respond_to do |format|
-      format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
-    end
+    redirect_to after_sign_out_path_for(:user)
   end
 end
 
@@ -37,7 +34,7 @@ describe Devise::SamlSessionsController, type: :controller do
 
   describe '#destroy' do
     it 'signs out and redirects to the IdP' do
-      expect(controller).to receive(:sign_out).and_call_original
+      expect(controller).to receive(:sign_out)
       delete :destroy
       expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
     end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -1,7 +1,14 @@
 require 'rails_helper'
 
 class Devise::SessionsController < ActionController::Base
-
+  # Copied from devise with unnecessary parts elided
+  def destroy
+    sign_out
+    respond_to do |format|
+      format.all { head :no_content }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+    end
+  end
 end
 
 require_relative '../../../app/controllers/devise/saml_sessions_controller'
@@ -18,13 +25,21 @@ describe Devise::SamlSessionsController, type: :controller do
   end
 
   describe '#metadata' do
-    it "generates metadata" do
+    it 'generates metadata' do
       get :metadata
 
       # Remove ID that can vary across requests
       expected_metadata = OneLogin::RubySaml::Metadata.new.generate(saml_config)
       metadata_pattern = Regexp.escape(expected_metadata).gsub(/ ID='[^']+'/, " ID='[\\w-]+'")
       expect(response.body).to match(Regexp.new(metadata_pattern))
+    end
+  end
+
+  describe '#destroy' do
+    it 'signs out and redirects to the IdP' do
+      expect(controller).to receive(:sign_out).and_call_original
+      delete :destroy
+      expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
     end
   end
 end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -1,18 +1,34 @@
 require 'rails_helper'
 
 class Devise::SessionsController < ActionController::Base
+  attr_accessor :warden
+
   # The important parts from devise
   def destroy
     sign_out
     redirect_to after_sign_out_path_for(:user)
   end
+
+  def navigational_formats
+    Devise.navigational_formats.select { |format| Mime::EXTENSION_LOOKUP[format.to_s] }
+  end
+
+  def resource_name
+    :user
+  end
 end
 
 require_relative '../../../app/controllers/devise/saml_sessions_controller'
 
-
 describe Devise::SamlSessionsController, type: :controller do
   let(:saml_config) { Devise.saml_config }
+
+  let(:warden) { double(:warden) }
+  let(:user_session) { {} }
+  before do
+    allow(warden).to receive(:session).with(:user).and_return(user_session)
+    controller.warden = warden
+  end
 
   describe '#new' do
     it 'redirects to the SAML Auth Request endpoint' do
@@ -37,6 +53,24 @@ describe Devise::SamlSessionsController, type: :controller do
       expect(controller).to receive(:sign_out)
       delete :destroy
       expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
+    end
+
+    context "when a logout assertion consumer service url is set" do
+      before do
+        @original_saml_config = Devise.saml_config
+        Devise.saml_config = Devise.saml_config.dup
+        Devise.saml_config.assertion_consumer_logout_service_url = "http://localhost:8020/users/signed_out"
+      end
+      after do
+        Devise.saml_config = @original_saml_config
+      end
+
+      it 'does not sign out, but sets logout transaction id' do
+      expect(controller).not_to receive(:sign_out).and_call_original
+      delete :destroy
+      expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
+      expect(controller.warden.session(:user)[:logout_request_id]).not_to be_nil
+      end
     end
   end
 end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -1,34 +1,18 @@
 require 'rails_helper'
 
 class Devise::SessionsController < ActionController::Base
-  attr_accessor :warden
-
   # The important parts from devise
   def destroy
     sign_out
     redirect_to after_sign_out_path_for(:user)
   end
-
-  def navigational_formats
-    Devise.navigational_formats.select { |format| Mime::EXTENSION_LOOKUP[format.to_s] }
-  end
-
-  def resource_name
-    :user
-  end
 end
 
 require_relative '../../../app/controllers/devise/saml_sessions_controller'
 
+
 describe Devise::SamlSessionsController, type: :controller do
   let(:saml_config) { Devise.saml_config }
-
-  let(:warden) { double(:warden) }
-  let(:user_session) { {} }
-  before do
-    allow(warden).to receive(:session).with(:user).and_return(user_session)
-    controller.warden = warden
-  end
 
   describe '#new' do
     it 'redirects to the SAML Auth Request endpoint' do
@@ -53,24 +37,6 @@ describe Devise::SamlSessionsController, type: :controller do
       expect(controller).to receive(:sign_out)
       delete :destroy
       expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
-    end
-
-    context "when a logout assertion consumer service url is set" do
-      before do
-        @original_saml_config = Devise.saml_config
-        Devise.saml_config = Devise.saml_config.dup
-        Devise.saml_config.assertion_consumer_logout_service_url = "http://localhost:8020/users/signed_out"
-      end
-      after do
-        Devise.saml_config = @original_saml_config
-      end
-
-      it 'does not sign out, but sets logout transaction id' do
-      expect(controller).not_to receive(:sign_out).and_call_original
-      delete :destroy
-      expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
-      expect(controller.warden.session(:user)[:logout_request_id]).not_to be_nil
-      end
     end
   end
 end

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'net/http'
+require 'timeout'
 require 'uri'
 require 'capybara/rspec'
 require 'capybara/webkit'
@@ -90,7 +91,13 @@ describe "SAML Authentication", type: :feature do
     fill_in "Email", with: "you@example.com"
     fill_in "Password", with: "asdf"
     click_on "Sign in"
-    expect(page).to have_content("you@example.com")
+    Timeout.timeout(Capybara.default_wait_time) do
+      loop do
+        sleep 0.1
+        break if current_url == "http://localhost:8020/"
+      end
+    end
+  rescue Timeout::Error
     expect(current_url).to eq("http://localhost:8020/")
   end
 end

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -32,6 +32,21 @@ describe "SAML Authentication", type: :feature do
       expect(page).to have_content("A User")
       expect(current_url).to eq("http://localhost:8020/")
     end
+
+    it "logs a user out of the IdP via the SP" do
+      sign_in
+
+      # prove user is still signed in
+      visit 'http://localhost:8020/'
+      expect(page).to have_content("you@example.com")
+      expect(current_url).to eq("http://localhost:8020/")
+
+      click_on "Log out"
+
+      # prove user is now signed out
+      visit 'http://localhost:8020/'
+      expect(current_url).to match(%r(\Ahttp://localhost:8009/saml/auth\?SAMLRequest=))
+    end
   end
 
   context "when the attributes are used to authenticate" do
@@ -67,5 +82,15 @@ describe "SAML Authentication", type: :feature do
   def create_user(email)
     response = Net::HTTP.post_form(URI('http://localhost:8020/users'), email: email)
     expect(response.code).to eq('201')
+  end
+
+  def sign_in
+    visit 'http://localhost:8020/'
+    expect(current_url).to match(%r(\Ahttp://localhost:8009/saml/auth\?SAMLRequest=))
+    fill_in "Email", with: "you@example.com"
+    fill_in "Password", with: "asdf"
+    click_on "Sign in"
+    expect(page).to have_content("you@example.com")
+    expect(current_url).to eq("http://localhost:8020/")
   end
 end

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -6,5 +6,7 @@ gem 'ruby-saml-idp'
 
 route "get '/saml/auth' => 'saml_idp#new'"
 route "post '/saml/auth' => 'saml_idp#create'"
+route "get '/saml/logout' => 'saml_idp#logout'"
 
 template File.expand_path('../saml_idp_controller.rb.erb', __FILE__), 'app/controllers/saml_idp_controller.rb'
+copy_file File.expand_path('../saml_idp-saml_slo_post.html.erb', __FILE__), 'app/views/saml_idp/saml_slo_post.html.erb'

--- a/spec/support/saml_idp-saml_slo_post.html.erb
+++ b/spec/support/saml_idp-saml_slo_post.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+</head>
+<body onload="document.forms[0].submit();" style="visibility:hidden;">
+<%= form_tag(@saml_slo_acs_url) do %>
+  <%= hidden_field_tag("SAMLResponse", @saml_slo_response) %>
+  <%= submit_tag "Submit" %>
+<% end %>
+</body>
+</html>

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -51,4 +51,72 @@ class SamlIdpController < SamlIdp::IdpController
   def include_subject_in_attributes
     <%= @include_subject_in_attributes %>
   end
+
+  # == SLO functionality, see https://github.com/lawrencepit/ruby-saml-idp/pull/10
+  skip_before_filter :validate_saml_request, :only => [:logout]
+  before_filter :validate_saml_slo_request, :only => [:logout]
+
+  public
+
+  def logout
+    _person, _logout = idp_slo_authenticate(params[:name_id])
+    if _person && _logout
+      @saml_slo_response = idp_make_saml_slo_response(_person)
+    else
+      @saml_idp_fail_msg = 'User not found'
+      logger.error "User with email #{params[:name_id]} not found"
+      @saml_slo_response = encode_SAML_SLO_Response(params[:name_id])
+    end
+    render :template => "saml_idp/idp/saml_slo_post", :layout => false
+  end
+
+  def idp_slo_authenticate(email)
+    true
+  end
+
+  def idp_make_saml_slo_response(person)
+    attributes = {}
+    if include_subject_in_attributes
+      attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"] = "you@example.com"
+    end
+    encode_SAML_SLO_Response("you@example.com", attributes: attributes)
+  end
+
+  private
+
+  def validate_saml_slo_request(saml_request = params[:SAMLRequest])
+    decode_SAML_SLO_Request(saml_request)
+  end
+
+  def decode_SAML_SLO_Request(saml_request)
+    zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+    @saml_slo_request = zstream.inflate(Base64.decode64(saml_request))
+    zstream.finish
+    zstream.close
+    @saml_slo_request_id = @saml_slo_request[/ID=['"](.+?)['"]/, 1]
+    @saml_slo_acs_url = @saml_slo_request[/AssertionConsumerLogoutServiceURL=['"](.+?)['"]/, 1]
+  end
+
+  def encode_SAML_SLO_Response(nameID, opts = {})
+    now = Time.now.utc
+    response_id, reference_id = UUID.generate, UUID.generate
+    audience_uri = opts[:audience_uri] || @saml_slo_acs_url[/^(.*?\/\/.*?\/)/, 1]
+    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
+
+    assertion = %[<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0"><Issuer>#{issuer_uri}</Issuer><Subject><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="#{@saml_slo_request_id}" NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_slo_acs_url}"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><AudienceRestriction><Audience>#{audience_uri}</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><AttributeValue>#{nameID}</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>]
+
+    digest_value = Base64.encode64(algorithm.digest(assertion)).gsub(/\n/, '')
+
+    signed_info = %[<ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod><ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-#{algorithm_name}"></ds:SignatureMethod><ds:Reference URI="#_#{reference_id}"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig##{algorithm_name}"></ds:DigestMethod><ds:DigestValue>#{digest_value}</ds:DigestValue></ds:Reference></ds:SignedInfo>]
+
+    signature_value = sign(signed_info).gsub(/\n/, '')
+
+    signature = %[<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">#{signed_info}<ds:SignatureValue>#{signature_value}</ds:SignatureValue><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>#{self.x509_certificate}</ds:X509Certificate></ds:X509Data></KeyInfo></ds:Signature>]
+
+    assertion_and_signature = assertion.sub(/Issuer\>\<Subject/, "Issuer>#{signature}<Subject")
+
+    xml = %[<samlp:LogoutResponse ID="_#{response_id}" Version="2.0" IssueInstant="#{now.iso8601}" Destination="#{@saml_slo_acs_url}" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" InResponseTo="#{@saml_slo_request_id}" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"><Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">#{issuer_uri}</Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" /></samlp:Status>#{assertion_and_signature}</samlp:LogoutResponse>]
+
+    Base64.encode64(xml)
+  end
 end

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -1,9 +1,21 @@
 class SamlIdpController < SamlIdp::IdpController
+  def new
+    if session[:user_id]
+      @saml_response = idp_make_saml_response(session[:user_id])
+      render :template => "saml_idp/idp/saml_post", :layout => false
+      return
+    end
+    super
+  end
+
+  protected
+
   def idp_authenticate(email, password)
+    session[:user_id] = "you@example.com"
     true
   end
 
-  def idp_make_saml_response(user)
+  def idp_make_saml_response(_)
     attributes = {
       "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" => "A User",
     }
@@ -67,10 +79,15 @@ class SamlIdpController < SamlIdp::IdpController
       logger.error "User with email #{params[:name_id]} not found"
       @saml_slo_response = encode_SAML_SLO_Response(params[:name_id])
     end
-    render :template => "saml_idp/idp/saml_slo_post", :layout => false
+    if @saml_slo_acs_url
+      render :template => "saml_idp/idp/saml_slo_post", :layout => false
+    else
+      redirect_to 'http://example.com'
+    end
   end
 
   def idp_slo_authenticate(email)
+    session.delete :user_id
     true
   end
 
@@ -100,7 +117,7 @@ class SamlIdpController < SamlIdp::IdpController
   def encode_SAML_SLO_Response(nameID, opts = {})
     now = Time.now.utc
     response_id, reference_id = UUID.generate, UUID.generate
-    audience_uri = opts[:audience_uri] || @saml_slo_acs_url[/^(.*?\/\/.*?\/)/, 1]
+    audience_uri = opts[:audience_uri] || (@saml_slo_acs_url && @saml_slo_acs_url[/^(.*?\/\/.*?\/)/, 1])
     issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
 
     assertion = %[<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0"><Issuer>#{issuer_uri}</Issuer><Subject><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="#{@saml_slo_request_id}" NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_slo_acs_url}"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><AudienceRestriction><Audience>#{audience_uri}</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><AttributeValue>#{nameID}</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>]


### PR DESCRIPTION
Add SLO support to the plugin.

Configuring an `idp_slo_target_url` gets you basic SLO, with no verification of the logout response from the IdP.

I removed support for the `assertion_consumer_logout_service_url` because ruby-saml does not support it in the logout request.

I had to pull in lawrencepit/ruby-saml-idp#10 into the fixture IdP so that it would support SLO too. I also added a persistent session to the IdP to ensure that logout was meaningful.

---

Removed section:

> If you care about the logout response, you can configure an `assertion_consumer_logout_service_url` and handle the response there, validating it against the request UUID. I added this mainly because I felt like someone would care, but if no one does we could simplify things greatly by dropping this use case.