### PR TITLE
Upgrade ruby-saml to ~> 1.0

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -19,7 +19,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
 
   def idp_sign_out
     if params[:SAMLRequest] && Devise.saml_session_index_key
-      logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], @saml_config)
+      logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], settings: @saml_config)
       resource_class.reset_session_key_for(logout_request.name_id)
 
       redirect_to generate_idp_logout_response(logout_request)

--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","1.0.0")
+  gem.add_dependency("ruby-saml","~> 1.0")
 end

--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","0.9.2")
+  gem.add_dependency("ruby-saml","1.0.0")
 end

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -1,4 +1,5 @@
 require 'devise/strategies/authenticatable' 
+
 module Devise
   module Strategies
     class SamlAuthenticatable < Authenticatable
@@ -15,7 +16,7 @@ module Devise
       def authenticate!
         @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: get_saml_config)
         resource = mapping.to.authenticate_with_saml(@response)
-        if @response.is_valid?
+        if @response.is_valid? && resource
           resource.after_saml_authentication(@response.sessionindex)
           success!(resource)
         else

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -13,8 +13,7 @@ module Devise
       end
 
       def authenticate!
-        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse])
-        @response.settings = get_saml_config
+        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: get_saml_config)
         resource = mapping.to.authenticate_with_saml(@response)
         if @response.is_valid?
           resource.after_saml_authentication(@response.sessionindex)

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -43,6 +43,15 @@ describe Devise::Strategies::SamlAuthenticatable do
       strategy.authenticate!
     end
 
+    context "and the resource cannot does not exist" do
+      let(:user) { nil }
+
+      it "fails to authenticate" do
+        expect(strategy).to receive(:fail!).with(:invalid)
+        strategy.authenticate!
+      end
+    end
+
     context "and the SAML response is not valid" do
       before do
         allow(response).to receive(:is_valid?).and_return(false)

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -35,8 +35,7 @@ describe Devise::Strategies::SamlAuthenticatable do
     end
 
     it "authenticates with the response" do
-      expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse])
-      expect(response).to receive(:settings=).with(saml_config)
+      expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse], settings: saml_config)
       expect(user_class).to receive(:authenticate_with_saml).with(response)
       expect(user).to receive(:after_saml_authentication).with(response.sessionindex)
 

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -37,7 +37,7 @@ class SamlIdpController < SamlIdp::IdpController
   def encode_SAMLResponse(nameID, opts = {})
     now = Time.now.utc
     response_id = UUID.generate
-    audience_uri = opts[:audience_uri] || saml_acs_url[/^(.*?\/\/.*?\/)/, 1]
+    audience_uri = opts[:audience_uri] || "#{saml_acs_url[/^(.*?\/\/.*?\/)/, 1]}saml/metadata"
     issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
 
     attributes = opts.fetch(:attributes, {})


### PR DESCRIPTION
- Adds support for encrypted assertions being set on the saml_config.
  ruby-saml requires you to pass the saml_settings in at initialization
  of the response object for this to work.
- Fixes expected audience endpoint.
- Permit ~> 1.0.0 of ruby-saml
- If the SAML response is valid but does not match any resource then the
strategy should return invalid.