### PR TITLE
Update user attributes on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ In config/initializers/devise.rb
     # Create user if the user does not exist. (Default is false)
     config.saml_create_user = true
 
+    # Update the attributes of the user after a successful login. (Default is false)
+    config.saml_update_user = true
+
     # Set the default user key. The user will be looked up by this key. Make
     # sure that the Authentication Response includes the attribute.
     config.saml_default_user_key = :email

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -26,6 +26,10 @@ module Devise
   mattr_accessor :saml_create_user
   @@saml_create_user = false
 
+  # Update user attributes after login
+  mattr_accessor :saml_update_user
+  @@saml_update_user = false
+
   mattr_accessor :saml_default_user_key
   @@saml_default_user_key
 
@@ -48,9 +52,7 @@ end
 # Add saml_authenticatable strategy to defaults.
 #
 Devise.add_module(:saml_authenticatable,
-                  :route => :saml_authenticatable, 
+                  :route => :saml_authenticatable,
                   :strategy   => true,
                   :controller => :saml_sessions,
                   :model  => 'devise_saml_authenticatable/model')
-
-

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -14,7 +14,7 @@ module Devise
       def update_with_password(params={})
         params.delete(:current_password)
         self.update_without_password(params)
-      end	
+      end
 
       def update_without_password(params={})
         params.delete(:password)
@@ -51,9 +51,14 @@ module Devise
             auth_value.try(:downcase!) if Devise.case_insensitive_keys.include?(key)
           end
           resource = where(key => auth_value).first
+
+          if (!resource.nil? && Devise.saml_update_user)
+            set_user_saml_attributes(resource,attributes)
+          end
+
           if (resource.nil? && !Devise.saml_create_user)
             logger.info("User(#{auth_value}) not found.  Not configured to create the user.")
-            return nil 
+            return nil
           end
 
           if (resource.nil? && Devise.saml_create_user)

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -14,6 +14,13 @@ describe Devise::Models::SamlAuthenticatable do
       def logger; end
     end
   end
+  class UserTest
+    attr_accessor :email, :name
+    def initialize(email, name)
+      @email = email
+      @name = name
+    end
+  end
 
   before do
     logger = double(:logger).as_null_object
@@ -90,7 +97,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
   end
 
-  context "when configured to create a user and the user is not found" do
+  context "when configured to create an user and the user is not found" do
     before do
       allow(Devise).to receive(:saml_create_user).and_return(true)
     end
@@ -103,6 +110,26 @@ describe Devise::Models::SamlAuthenticatable do
       expect(model.saved).to be(true)
     end
   end
+
+  context "when configured to update an user" do
+    before do
+      allow(Devise).to receive(:saml_update_user).and_return(true)
+    end
+
+    it "returns nil if the user is not found" do
+      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      expect(Model.authenticate_with_saml(response)).to be_nil
+    end
+
+    it "updates the attributes if the user is found" do
+      user = UserTest.new("old_mail@mail.com", "old name")
+      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])      
+      model = Model.authenticate_with_saml(response)
+      expect(model.email).to eq('user@example.com')
+      expect(model.name).to  eq('A User')
+    end
+  end
+
 
   context "when configured with a case-insensitive key" do
     before do


### PR DESCRIPTION
If you add a role to a user, that new role wouldn't previously be spotted by this gem.

This changeset adds the capability to update user attributes with each authentication.