### PR TITLE
Persist updated user attributes

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -54,6 +54,9 @@ module Devise
 
           if (!resource.nil? && Devise.saml_update_user)
             set_user_saml_attributes(resource, attributes)
+            if (Devise.saml_use_subject)
+              resource.send "#{key}=", auth_value
+            end
             resource.save!
           end
 

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -53,7 +53,8 @@ module Devise
           resource = where(key => auth_value).first
 
           if (!resource.nil? && Devise.saml_update_user)
-            set_user_saml_attributes(resource,attributes)
+            set_user_saml_attributes(resource, attributes)
+            resource.save!
           end
 
           if (resource.nil? && !Devise.saml_create_user)
@@ -64,7 +65,7 @@ module Devise
           if (resource.nil? && Devise.saml_create_user)
             logger.info("Creating user(#{auth_value}).")
             resource = new
-            set_user_saml_attributes(resource,attributes)
+            set_user_saml_attributes(resource, attributes)
             if (Devise.saml_use_subject)
               resource.send "#{key}=", auth_value
             end

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -52,22 +52,17 @@ module Devise
           end
           resource = where(key => auth_value).first
 
-          if (!resource.nil? && Devise.saml_update_user)
-            set_user_saml_attributes(resource, attributes)
-            if (Devise.saml_use_subject)
-              resource.send "#{key}=", auth_value
+          if resource.nil?
+            if Devise.saml_create_user
+              logger.info("Creating user(#{auth_value}).")
+              resource = new
+            else
+              logger.info("User(#{auth_value}) not found.  Not configured to create the user.")
+              return nil
             end
-            resource.save!
           end
 
-          if (resource.nil? && !Devise.saml_create_user)
-            logger.info("User(#{auth_value}) not found.  Not configured to create the user.")
-            return nil
-          end
-
-          if (resource.nil? && Devise.saml_create_user)
-            logger.info("Creating user(#{auth_value}).")
-            resource = new
+          if Devise.saml_update_user || (resource.new_record? && Devise.saml_create_user)
             set_user_saml_attributes(resource, attributes)
             if (Devise.saml_use_subject)
               resource.send "#{key}=", auth_value

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -7,6 +7,11 @@ describe Devise::Models::SamlAuthenticatable do
     def initialize(params = {})
       @email = params[:email]
       @name = params[:name]
+      @new_record = params.fetch(:new_record, true)
+    end
+
+    def new_record?
+      @new_record
     end
 
     def save!
@@ -51,7 +56,7 @@ describe Devise::Models::SamlAuthenticatable do
   let(:name_id) { nil }
 
   it "looks up the user by the configured default user key" do
-    user = double(:user)
+    user = Model.new(new_record: false)
     expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
     expect(Model.authenticate_with_saml(response)).to eq(user)
   end
@@ -70,7 +75,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "looks up the user by the configured default user key" do
-      user = double(:user)
+      user = Model.new(new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
       expect(Model.authenticate_with_saml(response)).to eq(user)
     end
@@ -100,7 +105,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "creates and returns a new user with the name identifier and given attributes" do
-        user = Model.new(email: "old_mail@mail.com", name: "old name")
+        user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
         expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
         model = Model.authenticate_with_saml(response)
         expect(model.email).to eq('user@example.com')
@@ -135,7 +140,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "updates the attributes if the user is found" do
-      user = Model.new(email: "old_mail@mail.com", name: "old name")
+      user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
       model = Model.authenticate_with_saml(response)
       expect(model.email).to eq('user@example.com')
@@ -151,7 +156,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "looks up the user with a downcased value" do
-      user = double(:user)
+      user = Model.new(new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
       expect(Model.authenticate_with_saml(response)).to eq(user)
     end

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -4,6 +4,11 @@ describe Devise::Models::SamlAuthenticatable do
   class Model
     include Devise::Models::SamlAuthenticatable
     attr_accessor :email, :name, :saved
+    def initialize(params = {})
+      @email = params[:email]
+      @name = params[:name]
+    end
+
     def save!
       self.saved = true
     end
@@ -12,13 +17,6 @@ describe Devise::Models::SamlAuthenticatable do
     class << self
       def where(*args); end
       def logger; end
-    end
-  end
-  class UserTest
-    attr_accessor :email, :name
-    def initialize(email, name)
-      @email = email
-      @name = name
     end
   end
 
@@ -122,11 +120,12 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "updates the attributes if the user is found" do
-      user = UserTest.new("old_mail@mail.com", "old name")
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])      
+      user = Model.new(email: "old_mail@mail.com", name: "old name")
+      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
       model = Model.authenticate_with_saml(response)
       expect(model.email).to eq('user@example.com')
       expect(model.name).to  eq('A User')
+      expect(model.saved).to be(true)
     end
   end
 

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -93,6 +93,21 @@ describe Devise::Models::SamlAuthenticatable do
         expect(model.saved).to be(true)
       end
     end
+
+    context "when configured to update a user and the user is found" do
+      before do
+        allow(Devise).to receive(:saml_update_user).and_return(true)
+      end
+
+      it "creates and returns a new user with the name identifier and given attributes" do
+        user = Model.new(email: "old_mail@mail.com", name: "old name")
+        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        model = Model.authenticate_with_saml(response)
+        expect(model.email).to eq('user@example.com')
+        expect(model.name).to  eq('A User')
+        expect(model.saved).to be(true)
+      end
+    end
   end
 
   context "when configured to create an user and the user is not found" do

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -34,6 +34,19 @@ describe "SAML Authentication", type: :feature do
       expect(current_url).to eq("http://localhost:8020/")
     end
 
+    it "updates a user on the SP from the IdP attributes" do
+      create_user("you@example.com")
+
+      visit 'http://localhost:8020/'
+      expect(current_url).to match(%r(\Ahttp://localhost:8009/saml/auth\?SAMLRequest=))
+      fill_in "Email", with: "you@example.com"
+      fill_in "Password", with: "asdf"
+      click_on "Sign in"
+      expect(page).to have_content("you@example.com")
+      expect(page).to have_content("A User")
+      expect(current_url).to eq("http://localhost:8020/")
+    end
+
     it "logs a user out of the IdP via the SP" do
       sign_in
 

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -36,6 +36,7 @@ after_bundle do
 
   config.saml_use_subject = #{use_subject_to_authenticate}
   config.saml_create_user = true
+  config.saml_update_user = true
 
   config.saml_configure do |settings|
     settings.assertion_consumer_service_url = "http://localhost:8020/users/saml/auth"


### PR DESCRIPTION
Follow up to #26:

> On review, I think this should be enhanced a bit.
>
> * The updates should be persisted, like they are when creating the user.
> * When subject is used as the auth value, it should be included in the update. Not every IdP includes the subject value in the attributes, so the subject might be erased if it's not included in the update.

Also added a feature spec.