### PR TITLE
Fix Travis failures

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--format doc
 --require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,8 @@ gemspec
 group :test do
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rails'
+  gem 'rails', '~> 4.0'
   gem 'rspec-rails'
   gem 'sqlite3'
   gem 'capybara-webkit'
 end
-

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -76,8 +76,8 @@ describe "SAML Authentication", type: :feature do
 
   context "when the attributes are used to authenticate" do
     before(:each) do
-      create_app('idp', %w(y))
-      create_app('sp', %w(n))
+      create_app('idp', 'INCLUDE_SUBJECT_IN_ATTRIBUTES' => "true")
+      create_app('sp', 'USE_SUBJECT_TO_AUTHENTICATE' => "false")
       @idp_pid = start_app('idp', idp_port)
       @sp_pid  = start_app('sp',  sp_port)
     end
@@ -91,8 +91,8 @@ describe "SAML Authentication", type: :feature do
 
   context "when the subject is used to authenticate" do
     before(:each) do
-      create_app('idp', %w(n))
-      create_app('sp', %w(y))
+      create_app('idp', 'INCLUDE_SUBJECT_IN_ATTRIBUTES' => "false")
+      create_app('sp', 'USE_SUBJECT_TO_AUTHENTICATE' => "true")
       @idp_pid = start_app('idp', idp_port)
       @sp_pid  = start_app('sp',  sp_port)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@ ENV["RAILS_ENV"] ||= 'test'
 
 require 'spec_helper'
 
-create_app('sp', %w(n))
+create_app('sp', 'USE_SUBJECT_TO_AUTHENTICATE' => "false")
 require 'support/sp/config/environment'
 require 'rspec/rails'
 

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -1,6 +1,6 @@
 # Set up a SAML IdP
 
-@include_subject_in_attributes = ask("Include the subject in the attributes?", limit: %w(y n)) == "y"
+@include_subject_in_attributes = ENV.fetch('INCLUDE_SUBJECT_IN_ATTRIBUTES')
 
 gem 'ruby-saml-idp'
 gem 'thin'

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -11,24 +11,13 @@ def app_ready?(pid, port)
     system("lsof -i:#{port}", out: '/dev/null')
 end
 
-def create_app(name, answers = [])
+def create_app(name, env = {})
   rails_new_options = %w(-T -J -S --skip-spring)
   rails_new_options << "-O" if name == 'idp'
   Bundler.with_clean_env do
     Dir.chdir(File.expand_path('../../support', __FILE__)) do
       FileUtils.rm_rf(name)
-      Open3.popen3("rails", "new", name, *rails_new_options, "-m", "#{name}_template.rb") do |stdin, stdout, stderr, wait_thread|
-        while answers.any?
-          question = stdout.gets
-          answer = answers.shift
-          stdin.puts answer
-          $stdout.puts "#{question} #{answer}"
-        end
-        wait_thread.join
-
-        $stdout.puts stdout.read
-        $stderr.puts stderr.read
-      end
+      system(env, "rails", "new", name, *rails_new_options, "-m", "#{name}_template.rb")
     end
   end
 end

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -1,6 +1,6 @@
 # Set up a SAML Service Provider
 
-use_subject_to_authenticate = ask("Use subject to authenticate?", limit: %w(y n)) == "y"
+use_subject_to_authenticate = ENV.fetch('USE_SUBJECT_TO_AUTHENTICATE')
 
 gem 'devise_saml_authenticatable', path: '../../..'
 gem 'thin'


### PR DESCRIPTION
Something changed in the dependencies of the Ruby 2.2 build on Travis and the builds are failing now. It appears to be an issue with providing input to the interactive rails templates for the feature tests. I've replaced the interactive pieces with environment variables so it can be more easily automated.