### PR TITLE
Lazy-load SAML config

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -3,23 +3,22 @@ require "ruby-saml"
 class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
   unloadable if Rails::VERSION::MAJOR < 4
-  before_filter :get_saml_config
   skip_before_filter :verify_authenticity_token
 
   def new
     request = OneLogin::RubySaml::Authrequest.new
-    action = request.create(@saml_config)
+    action = request.create(saml_config)
     redirect_to action
   end
-      
+
   def metadata
     meta = OneLogin::RubySaml::Metadata.new
-    render :xml => meta.generate(@saml_config)
+    render :xml => meta.generate(saml_config)
   end
 
   def idp_sign_out
     if params[:SAMLRequest] && Devise.saml_session_index_key
-      logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], settings: @saml_config)
+      logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], settings: saml_config)
       resource_class.reset_session_key_for(logout_request.name_id)
 
       redirect_to generate_idp_logout_response(logout_request)
@@ -42,12 +41,11 @@ class Devise::SamlSessionsController < Devise::SessionsController
   # Override devise to send user to IdP logout for SLO
   def after_sign_out_path_for(_)
     request = OneLogin::RubySaml::Logoutrequest.new
-    request.create(@saml_config)
+    request.create(saml_config)
   end
 
   def generate_idp_logout_response(logout_request)
     logout_request_id = logout_request.id
-    OneLogin::RubySaml::SloLogoutresponse.new.create(@saml_config, logout_request_id, nil)
+    OneLogin::RubySaml::SloLogoutresponse.new.create(saml_config, logout_request_id, nil)
   end
 end
-

--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -1,7 +1,9 @@
 require 'ruby-saml'
 module DeviseSamlAuthenticatable
   module SamlConfig
-    def get_saml_config
+    def saml_config
+      return @saml_config if @saml_config
+
       idp_config_path = "#{Rails.root}/config/idp.yml"
       # Support 0.0.x-style configuration via a YAML file
       if File.exists?(idp_config_path)

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -1,4 +1,4 @@
-require 'devise/strategies/authenticatable' 
+require 'devise/strategies/authenticatable'
 
 module Devise
   module Strategies
@@ -6,7 +6,7 @@ module Devise
       include DeviseSamlAuthenticatable::SamlConfig
       def valid?
         if params[:SAMLResponse]
-          response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], get_saml_config)
+          response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_config)
           !(response.response.include? 'LogoutResponse')
         else
           false
@@ -14,7 +14,7 @@ module Devise
       end
 
       def authenticate!
-        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: get_saml_config)
+        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config)
         resource = mapping.to.authenticate_with_saml(@response)
         if @response.is_valid? && resource
           resource.after_saml_authentication(@response.sessionindex)

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe DeviseSamlAuthenticatable::SamlConfig do
-  subject(:saml_config) { controller.get_saml_config }
+  subject(:saml_config) { controller.saml_config }
   let(:controller) { Class.new { include DeviseSamlAuthenticatable::SamlConfig }.new }
 
   # Replace global config since this test changes it

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -11,7 +11,7 @@ describe Devise::Strategies::SamlAuthenticatable do
 
   let(:saml_config) { OneLogin::RubySaml::Settings.new }
   before do
-    allow(strategy).to receive(:get_saml_config).and_return(saml_config)
+    allow(strategy).to receive(:saml_config).and_return(saml_config)
   end
 
   let(:mapping) { double(:mapping, to: user_class) }


### PR DESCRIPTION
Lazy-load the SAML config to avoid issues with before_filter ordering.

Devise [uses `prepend_before_filter`](https://github.com/plataformatec/devise/blob/v3.5.3/app/controllers/devise/sessions_controller.rb#L4) which ends up calling `after_sign_out_path_for`, which [in this gem](https://github.com/apokalipto/devise_saml_authenticatable/blob/f4ee1cf4b4105856dec38db5313bd3ea8cf91491/app/controllers/devise/saml_sessions_controller.rb#L45) uses the SAML config. If it hasn't been retrieved yet, it blows up.