### PR TITLE
Remove methods that conflict with devise_database_authenticatable

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -11,19 +11,6 @@ module Devise
         attr_accessor :password_confirmation
       end
 
-      def update_with_password(params={})
-        params.delete(:current_password)
-        self.update_without_password(params)
-      end
-
-      def update_without_password(params={})
-        params.delete(:password)
-        params.delete(:password_confirmation)
-
-        result = update_attributes(params)
-        result
-      end
-
       def after_saml_authentication(session_index)
         if Devise.saml_session_index_key && self.respond_to?(Devise.saml_session_index_key)
           self.update_attribute(Devise.saml_session_index_key, session_index)


### PR DESCRIPTION
As per the discussion in #45 this removes the `update_with_password` and `update_without_password` methods which conflict with `devise_database_authenticatable` causing database users to not be able to reset/update their password or any updates that require the password (i.e. an email on a user model). There were no tests covering these methods and no other specs failed.