### PR TITLE
Fix acceptance tests for older Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,12 @@ group :test do
   gem 'rspec-rails'
   gem 'sqlite3'
   gem 'capybara-webkit'
+
+  # Lock down versions of gems for older versions of Ruby
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
+    gem 'mime-types', '~> 2.99'
+  end
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
+    gem 'devise', '~> 3.5'
+  end
 end

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -5,6 +5,18 @@
 gem 'ruby-saml-idp'
 gem 'thin'
 
+insert_into_file('Gemfile', after: /\z/) {
+  <<-GEMFILE
+# Lock down versions of gems for older versions of Ruby
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
+  gem 'mime-types', '~> 2.99'
+end
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
+  gem 'devise', '~> 3.5'
+end
+  GEMFILE
+}
+
 route "get '/saml/auth' => 'saml_idp#new'"
 route "post '/saml/auth' => 'saml_idp#create'"
 route "get '/saml/logout' => 'saml_idp#logout'"

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -97,6 +97,7 @@ class SamlIdpController < SamlIdp::IdpController
     idp_slo_authenticate(params[:name_id])
     saml_slo_request = encode_SAML_SLO_Request("you@example.com")
     uri = URI.parse("http://localhost:8020/users/saml/idp_sign_out")
+    require 'net/http'
     Net::HTTP.post_form(uri, {"SAMLRequest" => saml_slo_request})
     head :no_content
   end

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -6,6 +6,18 @@ use_subject_to_authenticate = ENV.fetch('USE_SUBJECT_TO_AUTHENTICATE')
 gem 'devise_saml_authenticatable', path: '../../..'
 gem 'thin'
 
+insert_into_file('Gemfile', after: /\z/) {
+  <<-GEMFILE
+# Lock down versions of gems for older versions of Ruby
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
+  gem 'mime-types', '~> 2.99'
+end
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
+  gem 'devise', '~> 3.5'
+end
+  GEMFILE
+}
+
 create_file 'config/attribute-map.yml', <<-ATTRIBUTES
 ---
 "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": email


### PR DESCRIPTION
Ruby 1.9 and 2.0 are left out of the bright Rails and Devise future, so we need to lock down their versions when testing against those old Rubies.