### PR TITLE
Authentication error logging

### DIFF
--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -32,22 +32,19 @@ module Devise
       def parse_saml_response
         @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)))
         unless @response.is_valid?
-          DeviseSamlAuthenticatable::Logger.send("Auth errors: #{@response.errors.join(', ')}")
-          fail!(:invalid)
-          Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
+          failed_auth("Auth errors: #{@response.errors.join(', ')}")
         end
       end
 
       def retrieve_resource
         @resource = mapping.to.authenticate_with_saml(@response)
         if @resource.nil?
-          DeviseSamlAuthenticatable::Logger.send("Resource could not be found")
-          fail!(:invalid)
-          Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
+          failed_auth("Resource could not be found")
         end
       end
 
-      def failed_auth
+      def failed_auth(msg)
+        DeviseSamlAuthenticatable::Logger.send(msg)
         fail!(:invalid)
         Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
       end

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -13,15 +13,11 @@ module Devise
       end
 
       def authenticate!
-        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)))
-        resource = mapping.to.authenticate_with_saml(@response)
-        if @response.is_valid? && resource
-          resource.after_saml_authentication(@response.sessionindex)
-          success!(resource)
-        else
-          DeviseSamlAuthenticatable::Logger.send("Auth errors: #{@response.errors.join(', ')}")
-          fail!(:invalid)
-          Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
+        parse_saml_response
+        retrieve_resource unless self.halted?
+        unless self.halted?
+          @resource.after_saml_authentication(@response.sessionindex)
+          success!(@resource)
         end
       end
 
@@ -30,6 +26,30 @@ module Devise
       # Please let me know!
       def store?
         true
+      end
+
+      private
+      def parse_saml_response
+        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)))
+        unless @response.is_valid?
+          DeviseSamlAuthenticatable::Logger.send("Auth errors: #{@response.errors.join(', ')}")
+          fail!(:invalid)
+          Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
+        end
+      end
+
+      def retrieve_resource
+        @resource = mapping.to.authenticate_with_saml(@response)
+        if @resource.nil?
+          DeviseSamlAuthenticatable::Logger.send("Resource could not be found")
+          fail!(:invalid)
+          Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
+        end
+      end
+
+      def failed_auth
+        fail!(:invalid)
+        Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
       end
 
     end

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -19,6 +19,7 @@ module Devise
           resource.after_saml_authentication(@response.sessionindex)
           success!(resource)
         else
+          DeviseSamlAuthenticatable::Logger.send("Auth errors: #{@response.errors.join(', ')}")
           fail!(:invalid)
           Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
         end

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 describe Devise::Strategies::SamlAuthenticatable do
   subject(:strategy) { described_class.new(env, :user) }
   let(:env) { {} }
+  let(:errors) { ["Test1", "Test2"] }
 
-  let(:response) { double(:response, issuers: [idp_entity_id], :settings= => nil, is_valid?: true, sessionindex: '123123123') }
+  let(:response) { double(:response, issuers: [idp_entity_id], :settings= => nil, is_valid?: true, sessionindex: '123123123', errors: errors) }
   let(:idp_entity_id) { "https://test/saml/metadata/123123" }
   before do
     allow(OneLogin::RubySaml::Response).to receive(:new).and_return(response)
@@ -85,6 +86,11 @@ describe Devise::Strategies::SamlAuthenticatable do
         expect(strategy).to receive(:fail!).with(:invalid)
         strategy.authenticate!
       end
+
+      it 'logs the error' do
+        expect(DeviseSamlAuthenticatable::Logger).to receive(:send).with('Auth errors: Test1, Test2')
+        strategy.authenticate!
+      end
     end
 
     context "and the SAML response is not valid" do
@@ -101,6 +107,11 @@ describe Devise::Strategies::SamlAuthenticatable do
 
       after do
         Devise.saml_failed_callback = @saml_failed_login
+      end
+
+      it 'logs the error' do
+        expect(DeviseSamlAuthenticatable::Logger).to receive(:send).with('Auth errors: Test1, Test2')
+        strategy.authenticate!
       end
 
       it "fails to authenticate" do

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -88,7 +88,7 @@ describe Devise::Strategies::SamlAuthenticatable do
       end
 
       it 'logs the error' do
-        expect(DeviseSamlAuthenticatable::Logger).to receive(:send).with('Auth errors: Test1, Test2')
+        expect(DeviseSamlAuthenticatable::Logger).to receive(:send).with('Resource could not be found')
         strategy.authenticate!
       end
     end


### PR DESCRIPTION
Updates in the 1.3.0 version of ruby-saml improved the validation around SAML requests (https://github.com/onelogin/ruby-saml/pull/326).  This caused a bit of headache as new validation errors were causing our application to not authenticate.  It also surfaced the fact that validation errors are not being logged so it was near impossible to determine the source of the problem without deep diving.  This update reorganizes the authentication logic and ensures that errors are logged appropriately.  