### PR TITLE
RelayState option

### DIFF
--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -57,6 +57,11 @@ module Devise
   mattr_accessor :saml_failed_callback
   @@saml_failed_callback
 
+  # lambda that generates the RelayState param for the SAML AuthRequest, takes request
+  # from SamlSessionsController#new action as an argument
+  mattr_accessor :saml_relay_state
+  @@saml_relay_state
+
   mattr_accessor :saml_config
   @@saml_config = OneLogin::RubySaml::Settings.new
   def self.saml_configure

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -28,7 +28,7 @@ module Devise
       end
 
       module ClassMethods
-        def authenticate_with_saml(saml_response)
+        def authenticate_with_saml(saml_response, relay_state)
           key = Devise.saml_default_user_key
           attributes = saml_response.attributes
           if (Devise.saml_use_subject)

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -37,7 +37,7 @@ module Devise
       end
 
       def retrieve_resource
-        @resource = mapping.to.authenticate_with_saml(@response)
+        @resource = mapping.to.authenticate_with_saml(@response, params[:RelayState])
         if @resource.nil?
           failed_auth("Resource could not be found")
         end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -68,6 +68,16 @@ describe Devise::SamlSessionsController, type: :controller do
         do_get
       end
 
+      context "with a relay_state lambda defined" do
+        let(:relay_state) { ->(request) { "123" } }
+
+        it "includes the RelayState param in the request to the IdP" do
+          expect(Devise).to receive(:saml_relay_state).at_least(:once).and_return(relay_state)
+          do_get
+          expect(response).to redirect_to(%r(\Ahttp://idp_sso_url\?SAMLRequest=.*&RelayState=123))
+        end
+      end
+
       context "with a specified idp entity id reader" do
         class OurIdpEntityIdReader
           def self.entity_id(params)

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -58,12 +58,12 @@ describe Devise::Models::SamlAuthenticatable do
   it "looks up the user by the configured default user key" do
     user = Model.new(new_record: false)
     expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-    expect(Model.authenticate_with_saml(response)).to eq(user)
+    expect(Model.authenticate_with_saml(response, nil)).to eq(user)
   end
 
   it "returns nil if it cannot find a user" do
     expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-    expect(Model.authenticate_with_saml(response)).to be_nil
+    expect(Model.authenticate_with_saml(response, nil)).to be_nil
   end
 
   context "when configured to use the subject" do
@@ -77,12 +77,12 @@ describe Devise::Models::SamlAuthenticatable do
     it "looks up the user by the configured default user key" do
       user = Model.new(new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-      expect(Model.authenticate_with_saml(response)).to eq(user)
+      expect(Model.authenticate_with_saml(response, nil)).to eq(user)
     end
 
     it "returns nil if it cannot find a user" do
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-      expect(Model.authenticate_with_saml(response)).to be_nil
+      expect(Model.authenticate_with_saml(response, nil)).to be_nil
     end
 
     context "when configured to create a user and the user is not found" do
@@ -92,7 +92,7 @@ describe Devise::Models::SamlAuthenticatable do
 
       it "creates and returns a new user with the name identifier and given attributes" do
         expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-        model = Model.authenticate_with_saml(response)
+        model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
@@ -107,7 +107,7 @@ describe Devise::Models::SamlAuthenticatable do
       it "creates and returns a new user with the name identifier and given attributes" do
         user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
         expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-        model = Model.authenticate_with_saml(response)
+        model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
@@ -122,7 +122,7 @@ describe Devise::Models::SamlAuthenticatable do
 
     it "creates and returns a new user with the given attributes" do
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-      model = Model.authenticate_with_saml(response)
+      model = Model.authenticate_with_saml(response, nil)
       expect(model.email).to eq('user@example.com')
       expect(model.name).to  eq('A User')
       expect(model.saved).to be(true)
@@ -136,13 +136,13 @@ describe Devise::Models::SamlAuthenticatable do
 
     it "returns nil if the user is not found" do
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-      expect(Model.authenticate_with_saml(response)).to be_nil
+      expect(Model.authenticate_with_saml(response, nil)).to be_nil
     end
 
     it "updates the attributes if the user is found" do
       user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-      model = Model.authenticate_with_saml(response)
+      model = Model.authenticate_with_saml(response, nil)
       expect(model.email).to eq('user@example.com')
       expect(model.name).to  eq('A User')
       expect(model.saved).to be(true)
@@ -158,7 +158,7 @@ describe Devise::Models::SamlAuthenticatable do
     it "looks up the user with a downcased value" do
       user = Model.new(new_record: false)
       expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-      expect(Model.authenticate_with_saml(response)).to eq(user)
+      expect(Model.authenticate_with_saml(response, nil)).to eq(user)
     end
   end
 end


### PR DESCRIPTION
Add `saml_relay_state` confic option which uses a lambda to generate a `RelayState` parameter for the SAML AuthRequest from the rails `request`. This `RelayState` is passed back from the IdP and is propagated back to the `authenticate_with_saml` function which can be used for context when authenticating the user