### PR TITLE
Ability to set attribute_map via config setting

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -54,6 +54,12 @@ class Devise::SamlSessionsController < Devise::SessionsController
   end
 
   def generate_idp_logout_response(saml_config, logout_request_id)
-    OneLogin::RubySaml::SloLogoutresponse.new.create(saml_config, logout_request_id, nil)
+
+    params = {}
+    if Devise.saml_relay_state.present?
+      params['RelayState'] = relay_state
+    end
+
+    OneLogin::RubySaml::SloLogoutresponse.new.create(saml_config, logout_request_id, nil, params)
   end
 end

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -66,6 +66,10 @@ module Devise
   mattr_accessor :attribute_map
   @@attribute_map
 
+  # Instead of storing the attribute_map in attribute-map.yml, store it in the database, or set it programatically ...
+  mattr_accessor :set_user_saml_attributes_custom_function
+  set_user_saml_attributes_custom_function
+  
   mattr_accessor :saml_config
   @@saml_config = OneLogin::RubySaml::Settings.new
   def self.saml_configure

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -62,6 +62,10 @@ module Devise
   mattr_accessor :saml_relay_state
   @@saml_relay_state
 
+  # Instead of storing the attribute_map in attribute-map.yml, store it in the database, or set it programatically ...
+  mattr_accessor :attribute_map
+  @@attribute_map
+
   mattr_accessor :saml_config
   @@saml_config = OneLogin::RubySaml::Settings.new
   def self.saml_configure

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -66,10 +66,15 @@ module Devise
   mattr_accessor :attribute_map
   @@attribute_map
 
-  # Instead of storing the attribute_map in attribute-map.yml, store it in the database, or set it programatically ...
+  # Allow a block to be passed, to replace `set_user_saml_attributes` -- allowing more
+  # control over how the attributes are assigned to the user
   mattr_accessor :set_user_saml_attributes_custom_function
-  set_user_saml_attributes_custom_function
+  @@set_user_saml_attributes_custom_function
   
+  # Pass in a custom value for allowed_clock_drift
+  mattr_accessor :allowed_clock_drift_in_seconds
+  @@allowed_clock_drift_in_seconds
+
   mattr_accessor :saml_config
   @@saml_config = OneLogin::RubySaml::Settings.new
   def self.saml_configure

--- a/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
+++ b/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
@@ -2,9 +2,9 @@ module DeviseSamlAuthenticatable
   class DefaultIdpEntityIdReader
     def self.entity_id(params)
       if params[:SAMLRequest]
-        OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuer
+        OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], settings: Devise.saml_config, allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuer
       elsif params[:SAMLResponse]
-        OneLogin::RubySaml::Response.new(params[:SAMLResponse], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuers.first
+        OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: Devise.saml_config, allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuers.first
       end
     end
   end

--- a/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
+++ b/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
@@ -2,9 +2,9 @@ module DeviseSamlAuthenticatable
   class DefaultIdpEntityIdReader
     def self.entity_id(params)
       if params[:SAMLRequest]
-        OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest]).issuer
+        OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuer
       elsif params[:SAMLResponse]
-        OneLogin::RubySaml::Response.new(params[:SAMLResponse]).issuers.first
+        OneLogin::RubySaml::Response.new(params[:SAMLResponse], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil)).issuers.first
       end
     end
   end

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -71,7 +71,7 @@ module Devise
         end
 
         def attribute_map
-          @attribute_map ||= Devise.attribute_map || attribute_map_for_environment
+          Devise.attribute_map || attribute_map_for_environment
         end
 
         private

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -76,10 +76,14 @@ module Devise
 
         private
 
-        def set_user_saml_attributes(user,attributes)
-          attribute_map.each do |k,v|
-            Rails.logger.info "Setting: #{v}, #{attributes[k]}"
-            user.send "#{v}=", attributes[k]
+        def set_user_saml_attributes(user, attributes)
+          if defined?(Devise.set_user_saml_attributes_custom_function)
+            Devise.set_user_saml_attributes_custom_function.call(user, attributes)
+          else
+            attribute_map.each do |k, v|
+              Rails.logger.info "Setting: #{v}, #{attributes[k]}"
+              user.send "#{v}=", attributes[k]
+            end
           end
         end
 

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -71,7 +71,7 @@ module Devise
         end
 
         def attribute_map
-          @attribute_map ||= attribute_map_for_environment
+          @attribute_map ||= Devise.attribute_map || attribute_map_for_environment
         end
 
         private

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -43,7 +43,7 @@ module Devise
           if resource.nil?
             if Devise.saml_create_user
               logger.info("Creating user(#{auth_value}).")
-              resource = new
+              resource = new(:username => auth_value)
             else
               logger.info("User(#{auth_value}) not found.  Not configured to create the user.")
               return nil

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -6,7 +6,7 @@ module Devise
       include DeviseSamlAuthenticatable::SamlConfig
       def valid?
         if params[:SAMLResponse]
-          OneLogin::RubySaml::Response.new(params[:SAMLResponse])
+          OneLogin::RubySaml::Response.new(params[:SAMLResponse], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil))
         else
           false
         end
@@ -30,7 +30,7 @@ module Devise
 
       private
       def parse_saml_response
-        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)))
+        @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)), allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil))
         unless @response.is_valid?
           failed_auth("Auth errors: #{@response.errors.join(', ')}")
         end

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -6,7 +6,7 @@ module Devise
       include DeviseSamlAuthenticatable::SamlConfig
       def valid?
         if params[:SAMLResponse]
-          OneLogin::RubySaml::Response.new(params[:SAMLResponse], allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil))
+          OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_config(get_idp_entity_id(params)), allowed_clock_drift: (Devise.allowed_clock_drift_in_seconds || nil))
         else
           false
         end


### PR DESCRIPTION
Instead of storing the attribute_map in `attribute-map.yml`, store it in the database, or set it programmatically ...

Thank you for your lovely gem.  It is very useful to me.

In our case, our customers will be configuring SAML via a configuration panel.  They will be setting up the attribute map themselves.  If this is stored in the database, we can use classic Rails methods to create a nicer UI for them.  This way they don't need to go edit some strange file in the guts of our product.

Thanks again!
