### PR TITLE
Add hooks before saving resource

### DIFF
--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -67,6 +67,16 @@ module Devise
   def self.saml_configure
     yield saml_config
   end
+
+  mattr_reader :saml_default_update_resource_hook
+  @@saml_default_update_resource_hook = Proc.new do |user, saml_response|
+    saml_response.attributes.resource_keys.each do |key|
+      user.send "#{key}=", saml_response.attribute_value_by_resource_key(key)
+    end
+  end
+
+  mattr_accessor :saml_update_resource_hook
+  @@saml_update_resource_hook = @@saml_default_update_resource_hook
 end
 
 # Add saml_authenticatable strategy to defaults.

--- a/lib/devise_saml_authenticatable/saml_mapped_attributes.rb
+++ b/lib/devise_saml_authenticatable/saml_mapped_attributes.rb
@@ -1,0 +1,25 @@
+module SamlAuthenticatable
+  class SamlMappedAttributes
+    def initialize(attributes, attribute_map)
+      @attributes = attributes
+      @attribute_map = attribute_map
+      @inverted_attribute_map = @attribute_map.invert
+    end
+
+    def saml_attribute_keys()
+      @attribute_map.keys
+    end
+
+    def resource_keys()
+      @attribute_map.values
+    end
+
+    def value_by_resource_key(key)
+      value_by_saml_attribute_key(@inverted_attribute_map.fetch(String(key)))
+    end
+
+    def value_by_saml_attribute_key(key)
+      @attributes[String(key)]
+    end
+  end
+end

--- a/lib/devise_saml_authenticatable/saml_response.rb
+++ b/lib/devise_saml_authenticatable/saml_response.rb
@@ -1,0 +1,16 @@
+require 'devise_saml_authenticatable/saml_mapped_attributes'
+
+module SamlAuthenticatable
+  class SamlResponse
+    attr_reader :raw_response, :attributes
+
+    def initialize(saml_response, attribute_map)
+      @attributes = ::SamlAuthenticatable::SamlMappedAttributes.new(saml_response.attributes, attribute_map)
+      @raw_response = saml_response
+    end
+
+    def attribute_value_by_resource_key(key)
+      attributes.value_by_resource_key(key)
+    end
+  end
+end

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -178,4 +178,51 @@ describe Devise::Models::SamlAuthenticatable do
       include_examples "correct downcasing"
     end
   end
+
+  context "when configured to use a custom update hook" do
+    it "can replicate the default behaviour in a custom hook" do
+      configure_hook do |user, saml_response|
+        Devise.saml_default_update_resource_hook.call(user, saml_response)
+      end
+
+      new_user = Model.authenticate_with_saml(response, nil)
+
+      expect(new_user.name).to eq(attributes['saml-name-format'])
+      expect(new_user.email).to eq(attributes['saml-email-format'])
+    end
+
+    it "can extend the default behaviour with custom transformations" do
+      configure_hook do |user, saml_response|
+        Devise.saml_default_update_resource_hook.call(user, saml_response)
+
+        user.email = "ext+#{user.email}"
+      end
+
+      new_user = Model.authenticate_with_saml(response, nil)
+
+      expect(new_user.name).to eq(attributes['saml-name-format'])
+      expect(new_user.email).to eq("ext+#{attributes['saml-email-format']}")
+    end
+
+    it "can extend the default behaviour using information from the saml response" do
+      configure_hook do |user, saml_response|
+        Devise.saml_default_update_resource_hook.call(user, saml_response)
+
+        name_id = saml_response.raw_response.name_id
+        user.name += "@#{name_id}"
+      end
+
+      new_user = Model.authenticate_with_saml(response, nil)
+
+      expect(new_user.name).to eq("#{attributes['saml-name-format']}@#{response.name_id}")
+      expect(new_user.email).to eq(attributes['saml-email-format'])
+    end
+
+    def configure_hook(&block)
+      allow(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      allow(Devise).to receive(:saml_default_user_key).and_return(:email)
+      allow(Devise).to receive(:saml_create_user).and_return(true)
+      allow(Devise).to receive(:saml_update_resource_hook).and_return(block)
+    end
+  end
 end


### PR DESCRIPTION
Partly addresses https://github.com/apokalipto/devise_saml_authenticatable/issues/38

This PR introduces a mechanism to apply custom behaviour prior to saving
a resource. This behaviour occurs when `Devise.saml_update_user` or
`Devise.saml_create_user` has been enabled, and the resource has been
found or created. The mechanism works by means of introducing a hook
just prior to saving the resource, providing an application the
flexibility to make arbitrary changes to the resource.

This hook replaces the existing `set_user_saml_attributes` with a
default hook implementation which can be replaced or extended depending
on the application needs.

The changes are backward compatible to my knowledge, public
configuration has not been modified, but a new configuration has been
introduced (`saml_update_resource_hook`).
