### PR TITLE
Auth key should be case insensitive when it is an email address

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -40,7 +40,7 @@ module Devise
           auth_value.try(:downcase!) if Devise.case_insensitive_keys.include?(key)
 
           # Check if auth_value is an email address and if so, match using case insensitivity.
-          if auth_value.include?('@') && key.to_s.downcase.includes?('email')
+          if auth_value.include?('@') && key.to_s.downcase.include?('email')
             resource = where(key => auth_value).first
           else
             resource = where("lower(#{key}) = ?", auth_value.downcase).first

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -39,7 +39,12 @@ module Devise
           end
           auth_value.try(:downcase!) if Devise.case_insensitive_keys.include?(key)
 
-          resource = where(key => auth_value).first
+          # Check if auth_value is an email address and if so, match using case insensitivity.
+          if auth_value.include?('@') && key.to_s.downcase.includes?('email')
+            resource = where(key => auth_value).first
+          else
+            resource = where("lower(#{key}) = ?", auth_value.downcase).first
+          end
 
           if resource.nil?
             if Devise.saml_create_user

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -41,9 +41,9 @@ module Devise
 
           # Check if auth_value is an email address and if so, match using case insensitivity.
           if auth_value.include?('@') && key.to_s.downcase.include?('email')
-            resource = where(key => auth_value).first
-          else
             resource = where("lower(#{key}) = ?", auth_value.downcase).first
+          else
+            resource = where(key => auth_value).first
           end
 
           if resource.nil?

--- a/lib/devise_saml_authenticatable/version.rb
+++ b/lib/devise_saml_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseSamlAuthenticatable
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/lib/devise_saml_authenticatable/version.rb
+++ b/lib/devise_saml_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseSamlAuthenticatable
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end


### PR DESCRIPTION
This is a quick and dirty fix for #75. I didn't have time to write a proper spec for it (needed to get this on production ASAP). I'm not sure what the full implications of this are so I leave this PR open to discussion and critique. 

My thoughts are that emails should always be case insensitive, even if some IDPs/SPs store them in a case-sensitive manner, since it represents a unique index on a model.

The problem I encountered was that my client had hundreds of emails stored in their IDP such as `Foo.Bar@example.com`, which the standard SQL `where` clause does not match to the value `foo.bar@example.com` that is stored in my app's (the SP) database.