### PR TITLE
Add hook to resolve user object from saml response

### DIFF
--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -94,6 +94,20 @@ module Devise
   # updated with regards to the SAML response. See saml_default_update_resource_hook for an example.
   mattr_accessor :saml_update_resource_hook
   @@saml_update_resource_hook = @@saml_default_update_resource_hook
+
+  # Default resource locator. Uses saml_default_user_key and auth_value to resove user.
+  # See saml_resource_locator for more information.
+  mattr_reader :saml_default_resource_locator
+  @@saml_default_resource_locator = Proc.new do |model, saml_response, auth_value|
+    model.where(Devise.saml_default_user_key => auth_value).first
+  end
+
+  # Proc that is called to resolve the saml_response and auth_value into the correct user object.
+  # Recieves a copy of the ActiveRecord::Model, saml_response and auth_value. Is expected to return
+  # one instance of the provided model that is the matched account, or nil if none exists.
+  # See saml_default_resource_locator above for an example.
+  mattr_accessor :saml_resource_locator
+  @@saml_resource_locator = @@saml_default_resource_locator
 end
 
 # Add saml_authenticatable strategy to defaults.

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -95,7 +95,7 @@ module Devise
   mattr_accessor :saml_update_resource_hook
   @@saml_update_resource_hook = @@saml_default_update_resource_hook
 
-  # Default resource locator. Uses saml_default_user_key and auth_value to resove user.
+  # Default resource locator. Uses saml_default_user_key and auth_value to resolve user.
   # See saml_resource_locator for more information.
   mattr_reader :saml_default_resource_locator
   @@saml_default_resource_locator = Proc.new do |model, saml_response, auth_value|

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -42,7 +42,7 @@ module Devise
           end
           auth_value.try(:downcase!) if Devise.case_insensitive_keys.include?(key)
 
-          resource = where(key => auth_value).first
+          resource = Devise.saml_resource_locator.call(self, decorated_response, auth_value)
 
           if Devise.saml_resource_validator
             if not Devise.saml_resource_validator.new.validate(resource, saml_response)


### PR DESCRIPTION
As part of a project, I have been leveraging the gem's support for multiple IdPs, as we allow our users to configure their own IdPs to integrate with our system. Consequently when resolving users, it is not enough for us to just use one attribute to determine if a user exists in our system, as distinct users with the same usernames could exist in different IdPs.

For our purposes, we need to use something similar to
```User.where(username: auth_value, sso: saml_response.raw_response.destination)```
to resolve our users.

This PR adds a `saml_resource_locator` hook, which can convert the User model, SAML response and auth_value into either a pre-existing user, or `nil` if none already exists.

It also includes a `saml_default_resource_locator` which preserves existing resolution behaviour for those who do not need this hook.

Cheers,
Ash