### PR TITLE
Support Rails 4 and 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - "2.4.1"
 gemfile:
   - Gemfile
+  - spec/support/Gemfile.rails5
   - spec/support/Gemfile.rails4
   - spec/support/Gemfile.ruby-saml-1.3
 matrix:
@@ -15,13 +16,19 @@ matrix:
     - rvm: "1.9.3"
       gemfile: Gemfile
     - rvm: "1.9.3"
+      gemfile: spec/support/Gemfile.rails5
+    - rvm: "1.9.3"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
     - rvm: "2.0.0"
       gemfile: Gemfile
+    - rvm: "2.0.0"
+      gemfile: spec/support/Gemfile.rails5
     - rvm: "2.0.0"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
     - rvm: "2.1.10"
       gemfile: Gemfile
+    - rvm: "2.1.10"
+      gemfile: spec/support/Gemfile.rails5
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.0.0"
-  - "2.1.9"
-  - "2.2.5"
-  - "2.3.1"
+  - "2.1.10"
+  - "2.2.7"
+  - "2.3.4"
+  - "2.4.1"
 gemfile:
   - Gemfile
   - spec/support/Gemfile.rails4
@@ -19,9 +20,9 @@ matrix:
       gemfile: Gemfile
     - rvm: "2.0.0"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
-    - rvm: "2.1.9"
+    - rvm: "2.1.10"
       gemfile: Gemfile
-    - rvm: "2.1.9"
+    - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
 
 script:

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -3,7 +3,11 @@ require "ruby-saml"
 class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
   unloadable if Rails::VERSION::MAJOR < 4
-  skip_before_filter :verify_authenticity_token, raise: false
+  if Rails::VERSION::MAJOR < 5
+    skip_before_filter :verify_authenticity_token
+  else
+    skip_before_action :verify_authenticity_token, raise: false
+  end
 
   def new
     idp_entity_id = get_idp_entity_id(params)

--- a/spec/support/Gemfile.rails5
+++ b/spec/support/Gemfile.rails5
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in devise_saml_authenticatable.gemspec
-gemspec
+gemspec path: '../..'
 
 group :test do
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rails', '~> 5.1'
+  gem 'rails', '~> 5.0'
   gem 'rspec-rails'
   gem 'sqlite3'
   gem 'capybara'

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -3,6 +3,8 @@
 @include_subject_in_attributes = ENV.fetch('INCLUDE_SUBJECT_IN_ATTRIBUTES')
 @valid_destination = ENV.fetch('VALID_DESTINATION', "true")
 
+gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "34814fd41f91c493b89aa01ac73c44d241a31245b5bc5542fa4b7317525e1dcfa60ba947b3d085e4e229456fdee0d8af6aac6a63cf750d807ea6fe5d853dff4a"'
+
 gem 'ruby-saml-idp'
 gem 'thin'
 

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -5,7 +5,7 @@
 
 gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "34814fd41f91c493b89aa01ac73c44d241a31245b5bc5542fa4b7317525e1dcfa60ba947b3d085e4e229456fdee0d8af6aac6a63cf750d807ea6fe5d853dff4a"'
 
-gem 'ruby-saml-idp'
+gem 'ruby-saml-idp', git: "https://github.com/lawrencepit/ruby-saml-idp.git", ref: "ec715b252e849105c7a96df27b731c6e7f725a51"
 gem 'thin'
 
 insert_into_file('Gemfile', after: /\z/) {

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -24,7 +24,7 @@ def start_app(name, port, options = {})
   pid = nil
   Bundler.with_clean_env do
     Dir.chdir(File.expand_path("../../support/#{name}", __FILE__)) do
-      pid = Process.spawn("bundle exec rails server -p #{port}")
+      pid = Process.spawn({"RAILS_ENV" => "production"}, "bundle exec rails server -p #{port} -e production", out: "log/#{name}.log", err: "log/#{name}.err.log")
       sleep 1 until app_ready?(pid, port)
       if app_ready?(pid, port)
         puts "Launched #{name} on port #{port} (pid #{pid})..."

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -29,14 +29,14 @@ class SamlIdpController < SamlIdp::IdpController
 
   def session_index
     Rails.cache.fetch('session_key') {
-      UUID.generate
+      SecureRandom.uuid
     }
   end
 
 
   def encode_SAMLResponse(nameID, opts = {})
     now = Time.now.utc
-    response_id = UUID.generate
+    response_id = SecureRandom.uuid
     audience_uri = opts[:audience_uri] || "#{saml_acs_url[/^(.*?\/\/.*?\/)/, 1]}saml/metadata"
     issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
 
@@ -72,8 +72,13 @@ class SamlIdpController < SamlIdp::IdpController
   end
 
   # == SLO functionality, see https://github.com/lawrencepit/ruby-saml-idp/pull/10
+  <% if Rails::VERSION::MAJOR < 5 %>
   skip_before_filter :validate_saml_request, :only => [:logout, :sp_sign_out]
   before_filter :validate_saml_slo_request, :only => [:logout]
+  <% else %>
+  skip_before_action :validate_saml_request, :only => [:logout, :sp_sign_out]
+  before_action :validate_saml_slo_request, :only => [:logout]
+  <% end %>
 
   public
 
@@ -139,7 +144,7 @@ class SamlIdpController < SamlIdp::IdpController
 
   def encode_SAML_SLO_Response(nameID, opts = {})
     now = Time.now.utc
-    response_id = UUID.generate
+    response_id = SecureRandom.uuid
     audience_uri = opts[:audience_uri] || (@saml_slo_acs_url && @saml_slo_acs_url[/^(.*?\/\/.*?\/)/, 1])
     issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
 
@@ -175,7 +180,7 @@ class SamlIdpController < SamlIdp::IdpController
 
   def encode_SAML_SLO_Request(nameID, opts = {})
     now = Time.now.utc
-    response_id = UUID.generate
+    response_id = SecureRandom.uuid
     issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
     xml = %[<samlp:LogoutRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -8,6 +8,8 @@ idp_settings_adapter = ENV.fetch('IDP_SETTINGS_ADAPTER', "nil")
 idp_entity_id_reader = ENV.fetch('IDP_ENTITY_ID_READER', "DeviseSamlAuthenticatable::DefaultIdpEntityIdReader")
 saml_failed_callback = ENV.fetch('SAML_FAILED_CALLBACK', "nil")
 
+gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "8b5889df1fcf03f76c7d66da02d8776bcc85b06bed7d9c592f076d9c8a5455ee6d4beae45986c3c030b40208db5e612f2a6ef8283036a352e3fae83c5eda36be"'
+
 gem 'devise_saml_authenticatable', path: '../../..'
 gem 'ruby-saml', OneLogin::RubySaml::VERSION
 gem 'thin'
@@ -76,6 +78,8 @@ after_bundle do
   # Configure for our SAML IdP
   generate 'devise:install'
   gsub_file 'config/initializers/devise.rb', /^end$/, <<-CONFIG
+  config.secret_key = 'adc7cd73792f5d20055a0ac749ce8cdddb2e0f0d3ea7fe7855eec3d0f81833b9a4ac31d12e05f232d40ae86ca492826a6fc5a65228c6e16752815316e2d5b38d'
+
   config.saml_default_user_key = :email
   config.saml_session_index_key = #{saml_session_index_key}
 
@@ -111,6 +115,8 @@ end
 
   rake "db:create"
   rake "db:migrate"
+  rake "db:create", env: "production"
+  rake "db:migrate", env: "production"
 end
 
 create_file 'public/stylesheets/application.css', ''

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -108,7 +108,7 @@ class UsersController < ApplicationController
   skip_before_action :verify_authenticity_token
   def create
     User.create!(email: params[:email])
-    render nothing: true, status: 201
+    head 201
   end
 end
   USERS


### PR DESCRIPTION
Looks like adding support for Rails 5 actually broke support for Rails 4. `skip_before_filter ..., raise: false` is supposed to be benign for older Rails versions but it's actually not skipped. See Shopify/shopify_app#304 for more on the same issue.

Running the test applications in production mode exposes the issue. I added a version check like Shopify/shopify_app#315 did.

Incidentally, this can also add support for Rails 5.1 by using `skip_before_action` instead of `skip_before_filter` 👍 

Fixes #91.