### PR TITLE
Add license to gemspec

### DIFF
--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{SAML Authentication for devise}
   gem.summary       = %q{SAML Authentication for devise }
   gem.homepage      = ""
+  gem.license     = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I noticed this was missing while running an automated license audit.