### PR TITLE
rename routes to avoid override others devise strategies routes

### DIFF
--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","~> 1.3")
+  gem.add_dependency("ruby-saml","~> 1.8.0")
 end

--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","~> 1.8.0")
+  gem.add_dependency("ruby-saml","~> 1.3")
 end

--- a/lib/devise_saml_authenticatable/routes.rb
+++ b/lib/devise_saml_authenticatable/routes.rb
@@ -1,12 +1,13 @@
 ActionDispatch::Routing::Mapper.class_eval do
   protected
+
   def devise_saml_authenticatable(mapping, controllers)
-    resource :session, :only => [], :controller => controllers[:saml_sessions], :path => "" do
-      get :new, :path => "saml/sign_in", :as => "new"
-      post :create, :path=>"saml/auth"
-      match :destroy, :path => mapping.path_names[:sign_out], :as => "destroy", :via => mapping.sign_out_via
-      get :metadata, :path=>"saml/metadata"
-      match :idp_sign_out, :path=>"saml/idp_sign_out", via: [:get, :post]
+    resource :session, only: [], controller: controllers[:saml_sessions], path: '' do
+      get :new, path: 'saml/sign_in', as: :new_user_saml_session
+      post :create, path: 'saml/auth', as: :user_saml_session
+      match :destroy, path: mapping.path_names[:sign_out], as: :destroy_user_saml_session, via: mapping.sign_out_via
+      get :metadata, path: 'saml/metadata', as: :metadata_user_saml_session
+      match :idp_sign_out, path: 'saml/idp_sign_out', via: %i[get post]
     end
   end
 end


### PR DESCRIPTION
This changes avoid to create custom scopes for differents authentication strategies [Supporting multiple authentication strategies](https://github.com/apokalipto/devise_saml_authenticatable/wiki/Supporting-multiple-authentication-strategies) the routes

**extra:** I changed code styles 