### PR TITLE
Fix specs for older Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.ruby-saml-1.3
 
+before_install:
+  # update bundler to avoid https://github.com/travis-ci/travis-ci/issues/5239
+  - gem install bundler
+
 script:
   - bundle exec rake
 

--- a/spec/support/Gemfile.rails4
+++ b/spec/support/Gemfile.rails4
@@ -16,7 +16,11 @@ group :test do
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
     gem 'addressable', '~> 2.4.0'
     gem 'mime-types', '~> 2.99'
+    gem 'public_suffix', '~> 1.4.6'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
+    gem 'public_suffix', '~> 2.0.5'
   end
+
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
     gem 'devise', '~> 3.5'
     gem 'nokogiri', '~> 1.6.8'

--- a/spec/support/Gemfile.ruby-saml-1.3
+++ b/spec/support/Gemfile.ruby-saml-1.3
@@ -16,7 +16,11 @@ group :test do
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
     gem 'mime-types', '~> 2.99'
+    gem 'public_suffix', '~> 1.4.6'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
+    gem 'public_suffix', '~> 2.0.5'
   end
+
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
     gem 'devise', '~> 3.5'
     gem 'nokogiri', '~> 1.6.8'


### PR DESCRIPTION
We're still supporting Ruby 1.9 and Ruby 2.0, but more and more gems aren't. 

This PR pins those gems to old versions of `public_suffix` for old Rubies, and updates the included bundler to avoid an issue there.