### PR TITLE
Pass encryption settings to ruby-saml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-[![Build Status](https://travis-ci.org/apokalipto/devise_saml_authenticatable.svg?branch=master)](https://travis-ci.org/apokalipto/devise_saml_authenticatable)
 # DeviseSamlAuthenticatable
 
 Devise Saml Authenticatable is a Single-Sign-On authentication strategy for devise that relies on SAML.
 It uses [ruby-saml][] to handle all SAML-related stuff.
+
+## This fork exists to address [the original's issue #73](https://github.com/apokalipto/devise_saml_authenticatable/issues/73)
+
+It uses essentially the same changes proposed there.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ class IdPSettingsAdapter
   end
 end
 ```
+Settings specified in the adapter will override settings in `config/initializers/devise.rb`. This is useful for establishing common settings or defaults across all IdPs.
 
 Detecting the entity ID passed to the `settings` method is done by `config.idp_entity_id_reader`.
 
@@ -196,9 +197,11 @@ Logout requests from the IDP are supported by the `idp_sign_out` endpoint.  Dire
 
 `saml_session_index_key` must be configured to support this feature.
 
-## Signing and Encrypting Authentication Requests
+## Signing and Encrypting Authentication Requests and Assertions
 
 ruby-saml 1.0.0 supports signature and decrypt. The only requirement is to set the public certificate and the private key. For more information, see [the ruby-saml documentation](https://github.com/onelogin/ruby-saml#signing).
+
+If you have multiple IdPs, the certificate and private key must be in the shared settings in `config/initializers/devise.rb`.
 
 ## Thanks
 

--- a/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
+++ b/lib/devise_saml_authenticatable/default_idp_entity_id_reader.rb
@@ -4,11 +4,13 @@ module DeviseSamlAuthenticatable
       if params[:SAMLRequest]
         OneLogin::RubySaml::SloLogoutrequest.new(
           params[:SAMLRequest],
+          settings: Devise.saml_config,
           allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
         ).issuer
       elsif params[:SAMLResponse]
         OneLogin::RubySaml::Response.new(
           params[:SAMLResponse],
+          settings: Devise.saml_config,
           allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
         ).issuers.first
       end

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -8,6 +8,7 @@ module Devise
         if params[:SAMLResponse]
           OneLogin::RubySaml::Response.new(
             params[:SAMLResponse],
+            settings: Devise.saml_config,
             allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
           )
         else


### PR DESCRIPTION

Issue #73 identifies a problem with decrypting communication from the IdP: the certificate and private key are not passed to ruby-saml. @kevinmtrowbridge proposed a patch that got incorporated into a fork but never, apparently, this project.

This branch incorporates that code and adds two lines to `README.md` describing how it can be used even when the application uses an adapter to support multiple IdPs.

While this work eliminates some problems, the issue is not completely fixed: if there are multiple IdPs and the encryption settings are different for different providers, some other mechanism will be necessary to ensure the correct values are present in `Devise.saml_config`. 