### PR TITLE
Support Rails 5.2 in specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - "2.5.0"
 gemfile:
   - Gemfile
+  - spec/support/Gemfile.rails5.1
   - spec/support/Gemfile.rails5
   - spec/support/Gemfile.rails4
 matrix:
@@ -17,14 +18,20 @@ matrix:
       gemfile: Gemfile
     - rvm: "1.9.3"
       gemfile: spec/support/Gemfile.rails5
+    - rvm: "1.9.3"
+      gemfile: spec/support/Gemfile.rails5.1
     - rvm: "2.0.0"
       gemfile: Gemfile
     - rvm: "2.0.0"
       gemfile: spec/support/Gemfile.rails5
+    - rvm: "2.0.0"
+      gemfile: spec/support/Gemfile.rails5.1
     - rvm: "2.1.10"
       gemfile: Gemfile
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.rails5
+    - rvm: "2.1.10"
+      gemfile: spec/support/Gemfile.rails5.1
 
 before_install:
   # update bundler to avoid https://github.com/travis-ci/travis-ci/issues/5239

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -220,7 +220,7 @@ describe "SAML Authentication", type: :feature do
     fill_in "Email", with: "you@example.com"
     fill_in "Password", with: "asdf"
     click_on "Sign in"
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop do
         sleep 0.1
         break if current_url == "http://localhost:8020/"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,11 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.logger = Logger.new(nil)
-ActiveRecord::Migrator.migrate(File.expand_path("../support/sp/db/migrate/", __FILE__))
+if ActiveRecord::Base.connection.respond_to?(:migration_context)
+  ActiveRecord::Base.connection.migration_context.migrate
+else
+  ActiveRecord::Migrator.migrate(File.expand_path("../support/sp/db/migrate/", __FILE__))
+end
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true

--- a/spec/support/Gemfile.rails5.1
+++ b/spec/support/Gemfile.rails5.1
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in devise_saml_authenticatable.gemspec
+gemspec path: '../..'
+
+group :test do
+  gem 'rake'
+  gem 'rspec', '~> 3.0'
+  gem 'rails', '~> 5.1.0'
+  gem 'rspec-rails'
+  gem 'sqlite3'
+  gem 'capybara'
+  gem 'poltergeist'
+end

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -3,7 +3,9 @@
 @include_subject_in_attributes = ENV.fetch('INCLUDE_SUBJECT_IN_ATTRIBUTES')
 @valid_destination = ENV.fetch('VALID_DESTINATION', "true")
 
-gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "34814fd41f91c493b89aa01ac73c44d241a31245b5bc5542fa4b7317525e1dcfa60ba947b3d085e4e229456fdee0d8af6aac6a63cf750d807ea6fe5d853dff4a"'
+if Rails::VERSION::MAJOR < 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2)
+  gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "34814fd41f91c493b89aa01ac73c44d241a31245b5bc5542fa4b7317525e1dcfa60ba947b3d085e4e229456fdee0d8af6aac6a63cf750d807ea6fe5d853dff4a"'
+end
 
 gem 'ruby-saml-idp', git: "https://github.com/lawrencepit/ruby-saml-idp.git", ref: "ec715b252e849105c7a96df27b731c6e7f725a51"
 gem 'thin'

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -17,7 +17,7 @@ rescue Errno::ESRCH
 end
 
 def create_app(name, env = {})
-  rails_new_options = %w(-T -J -S --skip-spring --skip-listen)
+  rails_new_options = %w(-T -J -S --skip-spring --skip-listen --skip-bootsnap)
   rails_new_options << "-O" if name == 'idp'
   Dir.chdir(File.expand_path('../../support', __FILE__)) do
     FileUtils.rm_rf(name)

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -8,7 +8,9 @@ idp_settings_adapter = ENV.fetch('IDP_SETTINGS_ADAPTER', "nil")
 idp_entity_id_reader = ENV.fetch('IDP_ENTITY_ID_READER', "DeviseSamlAuthenticatable::DefaultIdpEntityIdReader")
 saml_failed_callback = ENV.fetch('SAML_FAILED_CALLBACK', "nil")
 
-gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "8b5889df1fcf03f76c7d66da02d8776bcc85b06bed7d9c592f076d9c8a5455ee6d4beae45986c3c030b40208db5e612f2a6ef8283036a352e3fae83c5eda36be"'
+if Rails::VERSION::MAJOR < 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2)
+  gsub_file 'config/secrets.yml', /secret_key_base:.*$/, 'secret_key_base: "8b5889df1fcf03f76c7d66da02d8776bcc85b06bed7d9c592f076d9c8a5455ee6d4beae45986c3c030b40208db5e612f2a6ef8283036a352e3fae83c5eda36be"'
+end
 
 gem 'devise_saml_authenticatable', path: '../../..'
 gem 'ruby-saml', OneLogin::RubySaml::VERSION


### PR DESCRIPTION
- Bootsnap doesn't work with templates that rely on installed gems, because it caches load paths before the gems are installed.
- Migrations are run using a different class & method
- Secrets were replaced with credentials, which come with a `secret_key_base` already in place