### PR TITLE
add SAML routes with multiple strategies in mind

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ In `config/routes.rb` add `devise_for` to set up helper methods and routes:
 devise_for :users
 ```
 
+The named routes can be customized in the initializer config file.
+
 ### Configuring the IdP
 
 An extra step in SAML SSO setup is adding your application to your identity provider. The required setup is specific to each IdP, but we have some examples in [our wiki](https://github.com/apokalipto/devise_saml_authenticatable/wiki). You'll need to tell your IdP how to send requests and responses to your application.
@@ -54,7 +56,7 @@ An extra step in SAML SSO setup is adding your application to your identity prov
     - IdPs may call this the "audience."
 - Single Logout: `/users/saml/idp_sign_out`
     - if desired, you can ask the IdP to send a Logout request to this endpoint to sign the user out of your application when they sign out of the IdP itself.
-    
+
 Your IdP should give you some information you need to configure in [ruby-saml](https://github.com/onelogin/ruby-saml), as in the next section:
 
 - Issuer (`idp_entity_id`)
@@ -101,6 +103,12 @@ In `config/initializers/devise.rb`:
     # You can set a handler object that takes the response for a failed SAML request and the strategy,
     # and implements a #handle method. This method can then redirect the user, return error messages, etc.
     # config.saml_failed_callback = nil
+
+    # You can customize the named routes generated in case of named route collisions with
+    # other Devise modules or libraries. Set the route_helper_prefix to a string that will
+    # be appended to the named route.
+    # If route_helper_prefix = 'saml' then the new_user_session route becomes new_saml_user_session
+    # config.route_helper_prefix = 'saml'
 
     # Configure with your SAML settings (see ruby-saml's README for more information: https://github.com/onelogin/ruby-saml).
     config.saml_configure do |settings|

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ In `config/initializers/devise.rb`:
     # config.saml_failed_callback = nil
 
     # You can customize the named routes generated in case of named route collisions with
-    # other Devise modules or libraries. Set the route_helper_prefix to a string that will
+    # other Devise modules or libraries. Set the saml_route_helper_prefix to a string that will
     # be appended to the named route.
-    # If route_helper_prefix = 'saml' then the new_user_session route becomes new_saml_user_session
-    # config.route_helper_prefix = 'saml'
+    # If saml_route_helper_prefix = 'saml' then the new_user_session route becomes new_saml_user_session
+    # config.saml_route_helper_prefix = 'saml'
 
     # Configure with your SAML settings (see ruby-saml's README for more information: https://github.com/onelogin/ruby-saml).
     config.saml_configure do |settings|

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -20,8 +20,8 @@ end
 # Get saml information from config/saml.yml now
 module Devise
   # Allow route customization to avoid collision
-  mattr_accessor :route_helper_prefix
-  @@route_helper_prefix
+  mattr_accessor :saml_route_helper_prefix
+  @@saml_route_helper_prefix
 
   # Allow logging
   mattr_accessor :saml_logger

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -19,6 +19,10 @@ end
 
 # Get saml information from config/saml.yml now
 module Devise
+  # Allow route customization to avoid collision
+  mattr_accessor :route_helper_prefix
+  @@route_helper_prefix
+
   # Allow logging
   mattr_accessor :saml_logger
   @@saml_logger = true

--- a/lib/devise_saml_authenticatable/routes.rb
+++ b/lib/devise_saml_authenticatable/routes.rb
@@ -1,8 +1,8 @@
 ActionDispatch::Routing::Mapper.class_eval do
   protected
   def devise_saml_authenticatable(mapping, controllers)
-    if ::Devise.route_helper_prefix
-      prefix = ::Devise.route_helper_prefix
+    if ::Devise.saml_route_helper_prefix
+      prefix = ::Devise.saml_route_helper_prefix
       resource :session, only: [], controller: controllers[:saml_sessions], path: '' do
         get :new, path: 'saml/sign_in', as: "new_#{prefix}"
         post :create, path: 'saml/auth', as: prefix

--- a/lib/devise_saml_authenticatable/routes.rb
+++ b/lib/devise_saml_authenticatable/routes.rb
@@ -1,12 +1,22 @@
 ActionDispatch::Routing::Mapper.class_eval do
   protected
   def devise_saml_authenticatable(mapping, controllers)
-    resource :session, :only => [], :controller => controllers[:saml_sessions], :path => "" do
-      get :new, :path => "saml/sign_in", :as => "new"
-      post :create, :path=>"saml/auth"
-      match :destroy, :path => mapping.path_names[:sign_out], :as => "destroy", :via => mapping.sign_out_via
-      get :metadata, :path=>"saml/metadata"
-      match :idp_sign_out, :path=>"saml/idp_sign_out", via: [:get, :post]
+    if mapping.modules.include? :database_authenticatable
+      resource :session, only: [], controller: controllers[:saml_sessions], path: '' do
+        get :new, path: 'saml/sign_in', as: :new_saml
+        post :create, path: 'saml/auth', as: :saml
+        match :destroy, path: mapping.path_names[:sign_out], as: :destroy_saml, via: mapping.sign_out_via
+        get :metadata, path: 'saml/metadata'
+        match :idp_sign_out, path: 'saml/idp_sign_out', as: :idp_destroy_saml, via: %i[get post]
+      end
+    else
+      resource :session, only: [], controller: controllers[:saml_sessions], path: '' do
+        get :new, path: 'saml/sign_in', as: 'new'
+        post :create, path: 'saml/auth'
+        match :destroy, path: mapping.path_names[:sign_out], as: 'destroy', via: mapping.sign_out_via
+        get :metadata, path: 'saml/metadata'
+        match :idp_sign_out, path: 'saml/idp_sign_out', via: %i[get post]
+      end
     end
   end
 end

--- a/lib/devise_saml_authenticatable/routes.rb
+++ b/lib/devise_saml_authenticatable/routes.rb
@@ -1,13 +1,14 @@
 ActionDispatch::Routing::Mapper.class_eval do
   protected
   def devise_saml_authenticatable(mapping, controllers)
-    if mapping.modules.include? :database_authenticatable
+    if ::Devise.route_helper_prefix
+      prefix = ::Devise.route_helper_prefix
       resource :session, only: [], controller: controllers[:saml_sessions], path: '' do
-        get :new, path: 'saml/sign_in', as: :new_saml
-        post :create, path: 'saml/auth', as: :saml
-        match :destroy, path: mapping.path_names[:sign_out], as: :destroy_saml, via: mapping.sign_out_via
+        get :new, path: 'saml/sign_in', as: "new_#{prefix}"
+        post :create, path: 'saml/auth', as: prefix
+        match :destroy, path: mapping.path_names[:sign_out], as: "destroy_#{prefix}", via: mapping.sign_out_via
         get :metadata, path: 'saml/metadata'
-        match :idp_sign_out, path: 'saml/idp_sign_out', as: :idp_destroy_saml, via: %i[get post]
+        match :idp_sign_out, path: 'saml/idp_sign_out', as: "idp_destroy_#{prefix}", via: %i[get post]
       end
     else
       resource :session, only: [], controller: controllers[:saml_sessions], path: '' do


### PR DESCRIPTION
**PR Summary**
This PR changes the `ActionDispatch::Routing::Mapper#devise_saml_authenticatable` behavior.

**Problem summary**
* Before this change, routes for `devise_saml_authenticatable` would conflict with Devise's own `database_authenticatable` routes when starting up the server:
```
vendor/bundle/ruby/2.2.0/gems/actionpack-4.2.0/lib/action_dispatch/routing/route_set.rb:538:in `add_route': Invalid route name, already in use: 'new_user_session'  (ArgumentError)
You may have defined two routes with the same name using the `:as` option, or you may be overriding a route already defined by a resource with the same naming. For the latter, you can restrict the routes created with `resources` as explained here:
http://guides.rubyonrails.org/routing.html#restricting-the-routes-created
```
* Modifying the default routes directly may impact the behavior of Devise for apps that don't use `database_authenticatable` as per discussion in PR #99. 
* Removing `:saml_authenticatable` from the resource model and setting custom routes to a custom controller per [this wiki](https://github.com/apokalipto/devise_saml_authenticatable/wiki/Supporting-multiple-authentication-strategies) requires the application to implement some of what's already implemented by this library.

**Change Summary**
This change introduces a check when defining routes for `devise_saml_authenticatable` to see if the mapping includes the `database_authenticatable` module. If the module exists, then the named routes are slightly modified to include the `saml` keyword to avoid conflict.  If the module does not exist, then the routes are mapped the same as before this PR.  I did not investigate if other modules would conflict with `devise_saml_authenticatable`, but most issues reported specify `database_authenticatable`, so I believe this should resolve #25 and related issues reported.

I did modify the syntax slightly based on some rubocop feedback such as `:k => v` to `k: v` and `"` to `'`.

Unfortunately I couldn't get specs to work before or after making these changes. I kept getting the following error, and I am too lazy right now to get to the bottom of them considering the change set:
```
An error occurred while loading ./spec/devise_saml_authenticatable/strategy_spec.rb.
Failure/Error: ActiveRecord::Base.logger = Logger.new(nil)

LoadError:
  Error loading the 'postgresql' Active Record adapter. Missing a gem it depends on? pg is not part of the bundle. Add it to your Gemfile.
# /Users/scottserok/.rvm/gems/ruby-2.3.7/gems/activerecord-5.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:4:in `<top (required)>'
...
# ./spec/rails_helper.rb:10:in `<top (required)>'
...
# ./spec/devise_saml_authenticatable/strategy_spec.rb:1:in `<top (required)>'
...
# ------------------
# --- Caused by: ---
# Gem::LoadError:
#   pg is not part of the bundle. Add it to your Gemfile.
#   /Users/scottserok/.rvm/gems/ruby-2.3.7/gems/activerecord-5.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:4:in `<top (required)>'
```
To manually test, I'm using this forked version and branch in my app and the routes are generated and the rails server starts without error.
```
$ rake routes | grep saml
                             new_saml_user_session GET      /users/saml/sign_in(.:format)                                                              devise/saml_sessions#new
                                 saml_user_session POST     /users/saml/auth(.:format)                                                                 devise/saml_sessions#create
                         destroy_saml_user_session DELETE   /users/logout(.:format)                                                                    devise/saml_sessions#destroy
                             metadata_user_session GET      /users/saml/metadata(.:format)                                                             devise/saml_sessions#metadata
                     idp_destroy_saml_user_session GET|POST /users/saml/idp_sign_out(.:format)                                                         devise/saml_sessions#idp_sign_out
```
If I removed `:database_authenticatable` from my User model, the routes are:
```
$ rake routes | grep saml
                                  new_user_session GET      /users/saml/sign_in(.:format)                                                              devise/saml_sessions#new
                                      user_session POST     /users/saml/auth(.:format)                                                                 devise/saml_sessions#create
                              destroy_user_session DELETE   /users/logout(.:format)                                                                    devise/saml_sessions#destroy
                             metadata_user_session GET      /users/saml/metadata(.:format)                                                             devise/saml_sessions#metadata
                         idp_sign_out_user_session GET|POST /users/saml/idp_sign_out(.:format)                                                         devise/saml_sessions#idp_sign_out
```

If you want to route to a custom controller, this is possible through the same mechanism Devise provides in `config/routes.rb':
```Ruby
Rails.application.routes.draw do
  devise_for :users, controllers: { saml_sessions: 'users/saml_sessions' }
```
```
$ rake routes | grep saml
                             new_saml_user_session GET      /users/saml/sign_in(.:format)                                                              users/saml_sessions#new
                                 saml_user_session POST     /users/saml/auth(.:format)                                                                 users/saml_sessions#create
                         destroy_saml_user_session DELETE   /users/logout(.:format)                                                                    users/saml_sessions#destroy
                             metadata_user_session GET      /users/saml/metadata(.:format)                                                             users/saml_sessions#metadata
                     idp_destroy_saml_user_session GET|POST /users/saml/idp_sign_out(.:format)                                                         users/saml_sessions#idp_sign_out