### PR TITLE
SamlException inherits from StandardError instead of Exception

### DIFF
--- a/lib/devise_saml_authenticatable/exception.rb
+++ b/lib/devise_saml_authenticatable/exception.rb
@@ -1,6 +1,6 @@
 module DeviseSamlAuthenticatable
 
-  class SamlException < Exception
+  class SamlException < StandardError
   end
 
 end


### PR DESCRIPTION
For more details:
https://www.honeybadger.io/blog/ruby-exception-vs-standarderror-whats-the-difference/
https://thoughtbot.com/blog/rescue-standarderror-not-exception