### PR TITLE
Added a configuration for clock drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ In `config/initializers/devise.rb`:
     # If saml_route_helper_prefix = 'saml' then the new_user_session route becomes new_saml_user_session
     # config.saml_route_helper_prefix = 'saml'
 
+    # You can add allowance for clock drift between the sp and idp.
+    # This is a time in seconds.
+    # config.allowed_clock_drift_in_seconds = 0
+
     # Configure with your SAML settings (see ruby-saml's README for more information: https://github.com/onelogin/ruby-saml).
     config.saml_configure do |settings|
       # assertion_consumer_service_url is required starting with ruby-saml 1.4.3: https://github.com/onelogin/ruby-saml#updating-from-142-to-143


### PR DESCRIPTION
ruby-saml allows for adding a configuration for clock drift. The place that this gets called in devise_saml_authenticatable is in devise_saml_authenticatable/lib/devise_saml_authenticatable/strategy.rb:40. 

As we were having a problem with clock drift, it seemed like having an easy place to configure this in this gem made the most sense. 

There were 24 failing tests but I can't imagine that was a result of my change.

Finished in 9 minutes 13 seconds (files took 31.96 seconds to load)
109 examples, 24 failures