### PR TITLE
Support single and multi value attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,18 @@ In the config directory, create a YAML file (`attribute-map.yml`) that maps SAML
 ```yaml
   # attribute-map.yml
 
-  "urn:mace:dir:attribute-def:uid": "user_name"
-  "urn:mace:dir:attribute-def:email": "email"
-  "urn:mace:dir:attribute-def:name": "last_name"
-  "urn:mace:dir:attribute-def:givenName": "name"
+  "urn:mace:dir:attribute-def:email":
+    "resource_key": "email"
+    "attribute_type": "single"
+  "urn:mace:dir:attribute-def:name":
+    "resource_key": "last_name"
+    "attribute_type": "single"
+  "urn:mace:dir:attribute-def:name":
+    "resource_key": "first_name"
+    "attribute_type": "single"
+  "urn:mace:dir:attribute-def:roles":
+    "resource_key": "roles"
+    "attribute_type": "multi"
 ```
 
 The attribute mappings are very dependent on the way the IdP encodes the attributes.

--- a/lib/devise_saml_authenticatable/saml_mapped_attributes.rb
+++ b/lib/devise_saml_authenticatable/saml_mapped_attributes.rb
@@ -10,20 +10,20 @@ module SamlAuthenticatable
     end
 
     def resource_keys
-      @attribute_map.values
+      @attribute_map.values.map { |h| h["resource_key"] }
     end
 
     def value_by_resource_key(key)
       str_key = String(key)
 
       # Find all of the SAML attributes that map to the resource key
-      attribute_map_for_key = @attribute_map.select { |_, resource_key| String(resource_key) == str_key }
+      attribute_map_for_key = @attribute_map.select { |_, config| String(config["resource_key"]) == str_key }
 
       saml_value = nil
 
       # Find the first non-nil value
-      attribute_map_for_key.each_key do |saml_key|
-        saml_value = value_by_saml_attribute_key(saml_key)
+      attribute_map_for_key.each_pair do |saml_key, config|
+        saml_value = value_by_saml_attribute_key(saml_key, config)
 
         break unless saml_value.nil?
       end
@@ -31,8 +31,8 @@ module SamlAuthenticatable
       saml_value
     end
 
-    def value_by_saml_attribute_key(key)
-      @attributes[String(key)]
+    def value_by_saml_attribute_key(key, config)
+      @attributes.send(config["attribute_type"], String(key))
     end
   end
 end


### PR DESCRIPTION
I think it is essential to handle both single and multi value attributes as Identity Providers often send
responses containing both types, e.g. single for email and multi for roles.

I have provided an example of the new attribute map yaml. The type is configureable per attribute.

The change is not backwards compatible but it would be relatively easy to add if it is a 
blocking issue.