### PR TITLE
Test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       gemfile: spec/support/Gemfile.rails5
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.rails5.1
+    - rvm: "2.2.10"
+      gemfile: Gemfile
     - rvm: "2.6.3"
       gemfile: spec/support/Gemfile.rails4
 

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -32,16 +32,16 @@ class Devise::SamlSessionsController < Devise::SessionsController
 
       redirect_to generate_idp_logout_response(saml_config, logout_request.id)
     elsif params[:SAMLResponse]
-      #Currently Devise handles the session invalidation when the request is made.
-      #To support a true SP initiated logout response, the request ID would have to be tracked and session invalidated
-      #based on that.
+      # Currently Devise handles the session invalidation when the request is made.
+      # To support a true SP initiated logout response, the request ID would have to be tracked and session invalidated
+      # based on that.
       if Devise.saml_sign_out_success_url
         redirect_to Devise.saml_sign_out_success_url
       else
         redirect_to action: :new
       end
     else
-      head :invalid_request
+      head 500
     end
   end
 

--- a/spec/support/idp_settings_adapter.rb.erb
+++ b/spec/support/idp_settings_adapter.rb.erb
@@ -2,15 +2,15 @@ class IdpSettingsAdapter
   def self.settings(idp_entity_id)
     if idp_entity_id == "http://localhost:8020/saml/metadata"
       {
-          assertion_consumer_service_url: "acs_url",
+          assertion_consumer_service_url: "http://localhost:8020/users/saml/auth",
           assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
           name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           issuer: "sp_issuer",
           idp_entity_id: "http://localhost:8020/saml/metadata",
           authn_context: "",
-          idp_slo_target_url: "http://www.example.com/slo",
-          idp_sso_target_url: "http://www.example.com/sso",
-          idp_cert: "idp_cert"
+          idp_slo_target_url: "http://localhost:8010/saml/logout",
+          idp_sso_target_url: "http://localhost:8010/saml/auth",
+          idp_cert_fingerprint: "9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D"
       }
     else
       {}

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -22,7 +22,7 @@ def create_app(name, env = {})
   Bundler.with_clean_env do
     Dir.chdir(File.expand_path('../../support', __FILE__)) do
       FileUtils.rm_rf(name)
-      system(env, "rails", "new", name, *rails_new_options, "-m", "#{name}_template.rb")
+      system(env, "rails", "_#{Rails.version}_", "new", name, *rails_new_options, "-m", "#{name}_template.rb")
     end
   end
 end


### PR DESCRIPTION
- Execute rails using correct version
    - Rails 6 introduced version conflicts with earlier versions, specifically in sqlite3
- Correct use of status symbol in Rails 6
- Ruby 2.2 cannot run the latest Rails 5.2, so allow that to fail
- Fix some tests that fail due to followed redirects in Capybara