### PR TITLE
Add Rails 6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ rvm:
   - "2.1.10"
   - "2.2.10"
   - "2.3.8"
-  - "2.4.6"
-  - "2.5.5"
-  - "2.6.3"
+  - "2.4.9"
+  - "2.5.7"
+  - "2.6.5"
+  - "2.7.0"
 gemfile:
   - Gemfile
+  - spec/support/Gemfile.rails5.2
   - spec/support/Gemfile.rails5.1
   - spec/support/Gemfile.rails5
   - spec/support/Gemfile.rails4
@@ -20,15 +22,27 @@ matrix:
       gemfile: spec/support/Gemfile.rails5
     - rvm: "2.0.0"
       gemfile: spec/support/Gemfile.rails5.1
+    - rvm: "2.0.0"
+      gemfile: spec/support/Gemfile.rails5.2
     - rvm: "2.1.10"
       gemfile: Gemfile
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.rails5
     - rvm: "2.1.10"
       gemfile: spec/support/Gemfile.rails5.1
+    - rvm: "2.1.10"
+      gemfile: spec/support/Gemfile.rails5.2
     - rvm: "2.2.10"
       gemfile: Gemfile
+    - rvm: "2.2.10"
+      gemfile: spec/support/Gemfile.rails5.2
+    - rvm: "2.3.8"
+      gemfile: Gemfile
+    - rvm: "2.4.9"
+      gemfile: Gemfile
     - rvm: "2.6.3"
+      gemfile: spec/support/Gemfile.rails4
+    - rvm: "2.7.0"
       gemfile: spec/support/Gemfile.rails4
 
 before_install:

--- a/spec/support/Gemfile.rails5.2
+++ b/spec/support/Gemfile.rails5.2
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in devise_saml_authenticatable.gemspec
-gemspec
+gemspec path: '../..'
 
 group :test do
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rails', '~> 6.0'
+  gem 'rails', '~> 5.2'
   gem 'rspec-rails'
-  gem 'sqlite3', '~> 1.4.0'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'capybara'
   gem 'poltergeist'
 


### PR DESCRIPTION
Continue to support Rails 4 in the tests, but we may want to drop support at one point now that we're straddling three major versions.