### PR TITLE
Install from GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,4 @@ group :test do
   gem 'sqlite3', '~> 1.4.0'
   gem 'capybara'
   gem 'poltergeist'
-
-  # Lock down versions of gems for older versions of Ruby
-  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
-    gem 'byebug', '~> 11.0.0'
-    gem 'responders', '~> 2.4'
-  end
 end

--- a/README.md
+++ b/README.md
@@ -6,17 +6,14 @@ It uses [ruby-saml][] to handle all SAML-related stuff.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this gem to your application's Gemfile:
 
-    gem 'devise_saml_authenticatable'
+    git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+    gem "devise_saml_authenticatable", github: "apokalipto/devise_saml_authenticatable"
 
 And then execute:
 
     $ bundle
-
-Or install it yourself as:
-
-    $ gem install devise_saml_authenticatable
 
 ## Usage
 

--- a/lib/devise_saml_authenticatable/version.rb
+++ b/lib/devise_saml_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseSamlAuthenticatable
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end

--- a/spec/support/Gemfile.rails4
+++ b/spec/support/Gemfile.rails4
@@ -28,6 +28,7 @@ group :test do
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
     gem 'responders', '~> 1.0'
   elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.0'
   end
 end

--- a/spec/support/Gemfile.rails4
+++ b/spec/support/Gemfile.rails4
@@ -31,7 +31,9 @@ group :test do
     gem 'responders', '~> 2.0'
   end
 
-  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.2")
+    gem 'byebug', '~> 9.0'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
     gem 'byebug', '~> 10.0'
   elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
     gem 'byebug', '~> 11.0.0'

--- a/spec/support/Gemfile.rails4
+++ b/spec/support/Gemfile.rails4
@@ -28,7 +28,12 @@ group :test do
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
     gem 'responders', '~> 1.0'
   elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
-    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.0'
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
+    gem 'byebug', '~> 10.0'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
   end
 end

--- a/spec/support/Gemfile.rails5
+++ b/spec/support/Gemfile.rails5
@@ -14,7 +14,12 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
-    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
+    gem 'byebug', '~> 10.0'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
   end
 end

--- a/spec/support/Gemfile.rails5
+++ b/spec/support/Gemfile.rails5
@@ -14,6 +14,7 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
   end
 end

--- a/spec/support/Gemfile.rails5.1
+++ b/spec/support/Gemfile.rails5.1
@@ -14,7 +14,12 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
-    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
+    gem 'byebug', '~> 10.0'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
   end
 end

--- a/spec/support/Gemfile.rails5.1
+++ b/spec/support/Gemfile.rails5.1
@@ -14,6 +14,7 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
   end
 end

--- a/spec/support/Gemfile.rails5.2
+++ b/spec/support/Gemfile.rails5.2
@@ -14,7 +14,12 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
-    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3")
+    gem 'byebug', '~> 10.0'
+  elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
   end
 end

--- a/spec/support/Gemfile.rails5.2
+++ b/spec/support/Gemfile.rails5.2
@@ -14,6 +14,7 @@ group :test do
 
   # Lock down versions of gems for older versions of Ruby
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
+    gem 'byebug', '~> 11.0.0'
     gem 'responders', '~> 2.4'
   end
 end


### PR DESCRIPTION
Typically @apokalipto bumps the version right before releasing this gem to rubygems. I haven't heard from him in a while though, so let's just update the README to use GitHub for installation.

Since we're updating installation instructions to use Github directly, I also bumped the version so it's obviously newer than what's on rubygems.

Fixes #169.