### PR TITLE
return nil when creating/updating resource raises an exception

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -66,7 +66,12 @@ module Devise
           end
 
           if Devise.saml_update_user || (resource.new_record? && Devise.saml_create_user)
-            Devise.saml_update_resource_hook.call(resource, decorated_response, auth_value)
+            begin
+              Devise.saml_update_resource_hook.call(resource, decorated_response, auth_value)
+            rescue
+              logger.info("User(#{auth_value}) failed to create or update.")
+              return nil
+            end
           end
 
           resource

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -104,6 +104,12 @@ describe Devise::Models::SamlAuthenticatable do
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
       end
+
+      it "returns nil if it fails to create a user" do
+        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+        expect(Devise).to receive(:saml_update_resource_hook).and_raise(StandardError.new)
+        expect(Model.authenticate_with_saml(response, nil)).to be_nil
+      end
     end
 
     context "when configured to update a user and the user is found" do
@@ -118,6 +124,13 @@ describe Devise::Models::SamlAuthenticatable do
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
+      end
+
+      it "returns nil if it fails to update a user" do
+        user = Model.new(new_record: false)
+        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Devise).to receive(:saml_update_resource_hook).and_raise(StandardError.new)
+        expect(Model.authenticate_with_saml(response, nil)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This PR is for issue #144 
When creating or updating the resource raises an Exception, return nil from method authenticate_with_saml to fail the authetication