### PR TITLE
Replace Model::attribute_map method

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -33,7 +33,7 @@ module Devise
           key = Devise.saml_default_user_key
           decorated_response = ::SamlAuthenticatable::SamlResponse.new(
             saml_response,
-            Devise.saml_attribute_map_resolver.new(saml_response).attribute_map,
+            attribute_map(saml_response),
           )
           if Devise.saml_use_subject
             auth_value = saml_response.name_id
@@ -84,6 +84,10 @@ module Devise
 
         def find_for_shibb_authentication(conditions)
           find_for_authentication(conditions)
+        end
+
+        def attribute_map(saml_response = nil)
+          Devise.saml_attribute_map_resolver.new(saml_response).attribute_map
         end
       end
     end

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -385,4 +385,10 @@ describe Devise::Models::SamlAuthenticatable do
       allow(Devise).to receive(:saml_resource_locator).and_return(block)
     end
   end
+
+  describe "::attribute_map" do
+    it "returns the attribute map" do
+      expect(Model.attribute_map).to eq(attributemap)
+    end
+  end
 end


### PR DESCRIPTION
This public method was removed in #162, released in 1.6.0, which should not have included a breaking change. I put the method back and added a test to make sure it's not accidentally removed again.

Fixes #178. cc @jasonpoll