### PR TITLE
Revert "return nil when creating/updating resource raises an exception"

### DIFF
--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -66,12 +66,7 @@ module Devise
           end
 
           if Devise.saml_update_user || (resource.new_record? && Devise.saml_create_user)
-            begin
-              Devise.saml_update_resource_hook.call(resource, decorated_response, auth_value)
-            rescue
-              logger.info("User(#{auth_value}) failed to create or update.")
-              return nil
-            end
+            Devise.saml_update_resource_hook.call(resource, decorated_response, auth_value)
           end
 
           resource

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -104,12 +104,6 @@ describe Devise::Models::SamlAuthenticatable do
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
       end
-
-      it "returns nil if it fails to create a user" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
-        expect(Devise).to receive(:saml_update_resource_hook).and_raise(StandardError.new)
-        expect(Model.authenticate_with_saml(response, nil)).to be_nil
-      end
     end
 
     context "when configured to update a user and the user is found" do
@@ -124,13 +118,6 @@ describe Devise::Models::SamlAuthenticatable do
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
         expect(model.saved).to be(true)
-      end
-
-      it "returns nil if it fails to update a user" do
-        user = Model.new(new_record: false)
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
-        expect(Devise).to receive(:saml_update_resource_hook).and_raise(StandardError.new)
-        expect(Model.authenticate_with_saml(response, nil)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This reverts commit 773b511c3e78c74e7ba29742923d3d0a637dbc20.

Based on the conversation in https://github.com/apokalipto/devise_saml_authenticatable/issues/181, it seems like we might want to revert this commit so it won't mask future unforeseen errors. We should be able to either use the combination of inheriting `Devise::SamlSessionsController` and `rescue_from`, or the solution in https://github.com/apokalipto/devise_saml_authenticatable/issues/182#issuecomment-698392327.

cc @luke-zhou 