### PR TITLE
Use strings for class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ In `config/initializers/devise.rb`:
     # If you don't set it then email will be extracted from SAML assertation attributes.
     config.saml_use_subject = true
 
-    # You can support multiple IdPs by setting this value to a class that implements a #settings method which takes
-    # an IdP entity id as an argument and returns a hash of idp settings for the corresponding IdP.
-    config.idp_settings_adapter = nil
+    # You can support multiple IdPs by setting this value to the name of a class that implements a ::settings method
+    # which takes an IdP entity id as an argument and returns a hash of idp settings for the corresponding IdP.
+    # config.idp_settings_adapter = "MyIdPSettingsAdapter"
 
     # You provide you own method to find the idp_entity_id in a SAML message in the case of multiple IdPs
-    # by setting this to a custom reader class, or use the default.
-    # config.idp_entity_id_reader = DeviseSamlAuthenticatable::DefaultIdpEntityIdReader
+    # by setting this to the name of a custom reader class, or use the default.
+    # config.idp_entity_id_reader = "DeviseSamlAuthenticatable::DefaultIdpEntityIdReader"
 
     # You can set a handler object that takes the response for a failed SAML request and the strategy,
     # and implements a #handle method. This method can then redirect the user, return error messages, etc.
@@ -169,7 +169,7 @@ If you only have one IdP, you can use the config file above, or just return a si
     ...
     # ==> Configuration for :saml_authenticatable
 
-    config.saml_attribute_map_resolver = MyAttributeMapResolver
+    config.saml_attribute_map_resolver = "MyAttributeMapResolver"
   end
 ```
 

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -56,7 +56,7 @@ module Devise
 
   # Reader that can parse entity id from a SAMLMessage
   mattr_accessor :idp_entity_id_reader
-  @@idp_entity_id_reader ||= ::DeviseSamlAuthenticatable::DefaultIdpEntityIdReader
+  @@idp_entity_id_reader ||= "::DeviseSamlAuthenticatable::DefaultIdpEntityIdReader"
 
   # Implements a #handle method that takes the response and strategy as an argument
   mattr_accessor :saml_failed_callback
@@ -69,7 +69,7 @@ module Devise
 
   # Instead of storing the attribute_map in attribute-map.yml, store it in the database, or set it programatically
   mattr_accessor :saml_attribute_map_resolver
-  @@saml_attribute_map_resolver ||= ::DeviseSamlAuthenticatable::DefaultAttributeMapResolver
+  @@saml_attribute_map_resolver ||= "::DeviseSamlAuthenticatable::DefaultAttributeMapResolver"
 
   # Implements a #validate method that takes the retrieved resource and response right after retrieval,
   # and returns true if it's valid.  False will cause authentication to fail.

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -82,7 +82,15 @@ module Devise
         end
 
         def attribute_map(saml_response = nil)
-          Devise.saml_attribute_map_resolver.new(saml_response).attribute_map
+          attribute_map_resolver.new(saml_response).attribute_map
+        end
+
+        def attribute_map_resolver
+          if Devise.saml_attribute_map_resolver.respond_to?(:new)
+            Devise.saml_attribute_map_resolver
+          else
+            Devise.saml_attribute_map_resolver.constantize
+          end
         end
       end
     end

--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -22,7 +22,7 @@ module DeviseSamlAuthenticatable
     def adapter_based_config(idp_entity_id)
       config = Marshal.load(Marshal.dump(Devise.saml_config))
 
-      Devise.idp_settings_adapter.settings(idp_entity_id).each do |k,v|
+      idp_settings_adapter.settings(idp_entity_id).each do |k,v|
         acc = "#{k.to_s}=".to_sym
 
         if config.respond_to? acc
@@ -33,7 +33,23 @@ module DeviseSamlAuthenticatable
     end
 
     def get_idp_entity_id(params)
-      Devise.idp_entity_id_reader.entity_id(params)
+      idp_entity_id_reader.entity_id(params)
+    end
+
+    def idp_entity_id_reader
+      if Devise.idp_entity_id_reader.respond_to?(:entity_id)
+        Devise.idp_entity_id_reader
+      else
+        @idp_entity_id_reader ||= Devise.idp_entity_id_reader.constantize
+      end
+    end
+
+    def idp_settings_adapter
+      if Devise.idp_settings_adapter.respond_to?(:settings)
+        Devise.idp_settings_adapter
+      else
+        @idp_settings_adapter ||= Devise.idp_settings_adapter.constantize
+      end
     end
   end
 end

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -141,7 +141,7 @@ describe "SAML Authentication", type: :feature do
   context "when the idp_settings_adapter key is set" do
     before(:each) do
       create_app('idp', 'INCLUDE_SUBJECT_IN_ATTRIBUTES' => "false")
-      create_app('sp', 'USE_SUBJECT_TO_AUTHENTICATE' => "true", 'IDP_SETTINGS_ADAPTER' => "IdpSettingsAdapter", 'IDP_ENTITY_ID_READER' => "OurEntityIdReader")
+      create_app('sp', 'USE_SUBJECT_TO_AUTHENTICATE' => "true", 'IDP_SETTINGS_ADAPTER' => '"IdpSettingsAdapter"', 'IDP_ENTITY_ID_READER' => '"OurEntityIdReader"')
 
       # use a different port for this entity ID; configured in spec/support/idp_settings_adapter.rb.erb
       @idp_pid = start_app('idp', 8010)
@@ -204,7 +204,7 @@ describe "SAML Authentication", type: :feature do
       )
       create_app(
         "sp",
-        "ATTRIBUTE_MAP_RESOLVER" => "AttributeMapResolver",
+        "ATTRIBUTE_MAP_RESOLVER" => '"AttributeMapResolver"',
         "USE_SUBJECT_TO_AUTHENTICATE" => "true",
       )
       @idp_pid = start_app("idp", idp_port)

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -6,7 +6,7 @@ attribute_map_resolver = ENV.fetch("ATTRIBUTE_MAP_RESOLVER", "nil")
 saml_session_index_key = ENV.fetch('SAML_SESSION_INDEX_KEY', ":session_index")
 use_subject_to_authenticate = ENV.fetch('USE_SUBJECT_TO_AUTHENTICATE')
 idp_settings_adapter = ENV.fetch('IDP_SETTINGS_ADAPTER', "nil")
-idp_entity_id_reader = ENV.fetch('IDP_ENTITY_ID_READER', "DeviseSamlAuthenticatable::DefaultIdpEntityIdReader")
+idp_entity_id_reader = ENV.fetch('IDP_ENTITY_ID_READER', '"DeviseSamlAuthenticatable::DefaultIdpEntityIdReader"')
 saml_failed_callback = ENV.fetch('SAML_FAILED_CALLBACK', "nil")
 
 if Rails::VERSION::MAJOR < 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2)


### PR DESCRIPTION
Rails 6 introduces the zeitwerk autoloader, and is warning us that using constants during initialization is not supported.
We can avoid that by setting class *names* instead of the constants directly, and loading the constants at runtime.

Fixes #172.