### PR TITLE
Check user signed in before init sp logout

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -5,10 +5,10 @@ class Devise::SamlSessionsController < Devise::SessionsController
   unloadable if Rails::VERSION::MAJOR < 4
   if Rails::VERSION::MAJOR < 5
     skip_before_filter :verify_authenticity_token
-    prepend_before_filter :store_info_for_sp_initiated_logout, only: :destroy
+    prepend_before_filter :verify_signed_out_user, :store_info_for_sp_initiated_logout, only: :destroy
   else
     skip_before_action :verify_authenticity_token, raise: false
-    prepend_before_action :store_info_for_sp_initiated_logout, only: :destroy
+    prepend_before_action :verify_signed_out_user, :store_info_for_sp_initiated_logout, only: :destroy
   end
 
   def new

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -65,18 +65,24 @@ class Devise::SamlSessionsController < Devise::SessionsController
 
   # Override devise to send user to IdP logout for SLO
   def after_sign_out_path_for(_)
-    idp_entity_id = get_idp_entity_id(params)
-    request = OneLogin::RubySaml::Logoutrequest.new
-    saml_settings = saml_config(idp_entity_id).dup
+    # if user is signed out, verify_signed_out_user method will set a notice flash message
+    # based on that, will redirect user to after sign out path or create the SP initiated logout request
+    if flash[:notice].present?
+      Devise.saml_sign_out_success_url.presence || super
+    else
+      idp_entity_id = get_idp_entity_id(params)
+      request = OneLogin::RubySaml::Logoutrequest.new
+      saml_settings = saml_config(idp_entity_id).dup
 
-    # Add attributes to saml_settings which will later be used to create the SP
-    # initiated logout request
-    unless Devise.saml_config.name_identifier_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
-      saml_settings.name_identifier_value = @name_identifier_value_for_sp_initiated_logout
-      saml_settings.sessionindex = @sessionindex_for_sp_initiated_logout
+      # Add attributes to saml_settings which will later be used to create the SP
+      # initiated logout request
+      unless Devise.saml_config.name_identifier_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+        saml_settings.name_identifier_value = @name_identifier_value_for_sp_initiated_logout
+        saml_settings.sessionindex = @sessionindex_for_sp_initiated_logout
+      end
+
+      request.create(saml_settings)
     end
-
-    request.create(saml_settings)
   end
 
   def generate_idp_logout_response(saml_config, logout_request_id)

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -16,10 +16,6 @@ class Devise::SessionsController < DeviseController
     sign_out
     redirect_to after_sign_out_path_for(:user)
   end
-
-  def verify_signed_out_user
-    # no-op for these tests
-  end
 end
 
 require_relative '../../../app/controllers/devise/saml_sessions_controller'
@@ -172,79 +168,123 @@ describe Devise::SamlSessionsController, type: :controller do
   end
 
   describe '#destroy' do
-    before do
-      allow(controller).to receive(:sign_out)
-    end
+    subject { delete :destroy }
 
-    context "when using the default saml config" do
-      it "signs out and redirects to the IdP" do
-        delete :destroy
-        expect(controller).to have_received(:sign_out)
-        expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
-      end
-    end
-
-    context "when configured to use a non-transient name identifier" do
+    context "when user is signed out" do
       before do
-        allow(Devise.saml_config).to receive(:name_identifier_format).and_return("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent")
-      end
-
-      it "includes a LogoutRequest with the name identifier and session index", :aggregate_failures do
-        controller.current_user = Struct.new(:email, :session_index).new("user@example.com", "sessionindex")
-
-        actual_settings = nil
-        expect_any_instance_of(OneLogin::RubySaml::Logoutrequest).to receive(:create) do |_, settings|
-          actual_settings = settings
-          "http://localhost:8009/saml/logout"
-        end
-
-        delete :destroy
-        expect(actual_settings.name_identifier_value).to eq("user@example.com")
-        expect(actual_settings.sessionindex).to eq("sessionindex")
-      end
-    end
-
-    context "with a specified idp" do
-      before do
-        Devise.idp_settings_adapter = idp_providers_adapter
-      end
-
-      it "redirects to the associated IdP SSO target url" do
-        expect(DeviseSamlAuthenticatable::DefaultIdpEntityIdReader).to receive(:entity_id)
-        delete :destroy
-        expect(controller).to have_received(:sign_out)
-        expect(response).to redirect_to(%r(\Ahttp://idp_slo_url\?SAMLRequest=))
-      end
-
-      context "with a specified idp entity id reader" do
-        class OurIdpEntityIdReader
-          def self.entity_id(params)
-            params[:entity_id]
+        class Devise::SessionsController < DeviseController
+          def verify_signed_out_user
+            flash[:notice] = "The devise's already signed out message"
+            redirect_to after_sign_out_path_for(resource_class)
           end
         end
+      end
 
-        subject(:do_delete) {
-          if Rails::VERSION::MAJOR > 4
-            delete :destroy, params: {entity_id: "http://www.example.com"}
-          else
-            delete :destroy, entity_id: "http://www.example.com"
-          end
-        }
-
+      context "when Devise.saml_sign_out_success_url is set" do
         before do
-          @default_reader = Devise.idp_entity_id_reader
-          Devise.idp_entity_id_reader = OurIdpEntityIdReader # which will have some different behavior
+          allow(Devise).to receive(:saml_sign_out_success_url).and_return("http://localhost:8009/logged_out")
         end
 
-        after do
-          Devise.idp_entity_id_reader = @default_reader
+        it "redirect to saml_sign_out_success_url" do
+          is_expected.to redirect_to "http://localhost:8009/logged_out"
+        end
+      end
+
+      context "when Devise.saml_sign_out_success_url is not set" do
+        before do
+          class Devise::SessionsController < DeviseController
+            def after_sign_out_path_for(_)
+              "http://localhost:8009/logged_out"
+            end
+          end
         end
 
-        it "redirects to the associated IdP SLO target url" do
-          do_delete
+        it "redirect to devise's after sign out path" do
+          is_expected.to redirect_to "http://localhost:8009/logged_out"
+        end
+      end
+    end
+
+    context "when user is not signed out" do
+      before do
+        class Devise::SessionsController < DeviseController
+          def verify_signed_out_user
+            # no-op for these tests
+          end
+        end
+        allow(controller).to receive(:sign_out)
+      end
+
+      context "when using the default saml config" do
+        it "signs out and redirects to the IdP" do
+          delete :destroy
           expect(controller).to have_received(:sign_out)
-          expect(idp_providers_adapter).to have_received(:settings).with("http://www.example.com")
+          expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/logout\?SAMLRequest=))
+        end
+      end
+
+      context "when configured to use a non-transient name identifier" do
+        before do
+          allow(Devise.saml_config).to receive(:name_identifier_format).and_return("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent")
+        end
+
+        it "includes a LogoutRequest with the name identifier and session index", :aggregate_failures do
+          controller.current_user = Struct.new(:email, :session_index).new("user@example.com", "sessionindex")
+
+          actual_settings = nil
+          expect_any_instance_of(OneLogin::RubySaml::Logoutrequest).to receive(:create) do |_, settings|
+            actual_settings = settings
+            "http://localhost:8009/saml/logout"
+          end
+
+          delete :destroy
+          expect(actual_settings.name_identifier_value).to eq("user@example.com")
+          expect(actual_settings.sessionindex).to eq("sessionindex")
+        end
+      end
+
+      context "with a specified idp" do
+        before do
+          Devise.idp_settings_adapter = idp_providers_adapter
+        end
+
+        it "redirects to the associated IdP SSO target url" do
+          expect(DeviseSamlAuthenticatable::DefaultIdpEntityIdReader).to receive(:entity_id)
+          delete :destroy
+          expect(controller).to have_received(:sign_out)
           expect(response).to redirect_to(%r(\Ahttp://idp_slo_url\?SAMLRequest=))
+        end
+
+        context "with a specified idp entity id reader" do
+          class OurIdpEntityIdReader
+            def self.entity_id(params)
+              params[:entity_id]
+            end
+          end
+
+          subject(:do_delete) {
+            if Rails::VERSION::MAJOR > 4
+              delete :destroy, params: {entity_id: "http://www.example.com"}
+            else
+              delete :destroy, entity_id: "http://www.example.com"
+            end
+          }
+
+          before do
+            @default_reader = Devise.idp_entity_id_reader
+            Devise.idp_entity_id_reader = OurIdpEntityIdReader # which will have some different behavior
+          end
+
+          after do
+            Devise.idp_entity_id_reader = @default_reader
+          end
+
+          it "redirects to the associated IdP SLO target url" do
+            do_delete
+            expect(controller).to have_received(:sign_out)
+            expect(idp_providers_adapter).to have_received(:settings).with("http://www.example.com")
+            expect(response).to redirect_to(%r(\Ahttp://idp_slo_url\?SAMLRequest=))
+          end
         end
       end
     end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -8,9 +8,18 @@ class DeviseController < ApplicationController
     User
   end
 
+  def resource_name
+    "users"
+  end
+
   def require_no_authentication
   end
+
+  def set_flash_message!(key, kind, options = {})
+    flash[key] = I18n.t("devise.sessions.#{kind}")
+  end
 end
+
 class Devise::SessionsController < DeviseController
   def destroy
     sign_out


### PR DESCRIPTION
Context: If user clear session their self and then click logout button, the error page is displayed

Explain: 
- Devise::SessionsController already has `prepend_before_action :verify_signed_out_user, only: :destroy`
but Devise::SamlSessionsController < Devise::SessionsController has `prepend_before_action :store_info_for_sp_initiated_logout, only: :destroy`
-> the order is `store_info_for_sp_initiated_logout` -> `verify_signed_out_user` -> `destroy`
- when current user is not existed, the `store_info_for_sp_initiated_logout` will raise error when try to call `Devise.saml_name_identifier_retriever.call(current_user)` (line 62)

Solution: call `verify_signed_out_user` before `store_info_for_sp_initiated_logout`