### PR TITLE
Validate `InResponseTo` header in SAML responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ In `config/initializers/devise.rb`:
     # This is a time in seconds.
     # config.allowed_clock_drift_in_seconds = 0
 
+    # In SAML responses, validate that the identity provider has included an InResponseTo
+    # header that matches the ID of the SAML request. (Default is false)
+    # config.saml_validate_in_response_to = false
+
     # Configure with your SAML settings (see ruby-saml's README for more information: https://github.com/onelogin/ruby-saml).
     config.saml_configure do |settings|
       # assertion_consumer_service_url is required starting with ruby-saml 1.4.3: https://github.com/onelogin/ruby-saml#updating-from-142-to-143

--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -16,6 +16,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
     request = OneLogin::RubySaml::Authrequest.new
     auth_params = { RelayState: relay_state } if relay_state
     action = request.create(saml_config(idp_entity_id), auth_params || {})
+    session[:saml_transaction_id] = request.request_id
     redirect_to action
   end
 

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -67,6 +67,10 @@ module Devise
   mattr_accessor :saml_relay_state
   @@saml_relay_state
 
+  # Validate that the InResponseTo header in SAML responses matches the ID of the request.
+  mattr_accessor :saml_validate_in_response_to
+  @@saml_validate_in_response_to = false
+
   # Instead of storing the attribute_map in attribute-map.yml, store it in the database, or set it programatically
   mattr_accessor :saml_attribute_map_resolver
   @@saml_attribute_map_resolver ||= "::DeviseSamlAuthenticatable::DefaultAttributeMapResolver"

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -62,7 +62,7 @@ module Devise
         }
 
         if Devise.saml_validate_in_response_to
-          options[:matches_request_id] = request.session[:saml_transaction_id] || ""
+          options[:matches_request_id] = request.session[:saml_transaction_id] || "ID_MISSING"
         end
 
         options

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -8,8 +8,7 @@ module Devise
         if params[:SAMLResponse]
           OneLogin::RubySaml::Response.new(
             params[:SAMLResponse],
-            settings: saml_config(get_idp_entity_id(params)),
-            allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+            response_options,
           )
         else
           false
@@ -36,8 +35,7 @@ module Devise
       def parse_saml_response
         @response = OneLogin::RubySaml::Response.new(
           params[:SAMLResponse],
-          settings: saml_config(get_idp_entity_id(params)),
-          allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+          response_options,
         )
         unless @response.is_valid?
           failed_auth("Auth errors: #{@response.errors.join(', ')}")
@@ -57,6 +55,18 @@ module Devise
         Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback
       end
 
+      def response_options
+        options = {
+          settings: saml_config(get_idp_entity_id(params)),
+          allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+        }
+
+        if Devise.saml_validate_in_response_to
+          options[:matches_request_id] = request.session[:saml_transaction_id] || ""
+        end
+
+        options
+      end
     end
   end
 end

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -90,6 +90,11 @@ describe Devise::SamlSessionsController, type: :controller do
         do_get
         expect(response).to redirect_to(%r(\Ahttp://localhost:8009/saml/auth\?SAMLRequest=))
       end
+
+      it "stores saml_transaction_id in the session" do
+        do_get
+        expect(session[:saml_transaction_id]).to be_present
+      end
     end
 
     context "with a specified idp" do
@@ -100,6 +105,11 @@ describe Devise::SamlSessionsController, type: :controller do
       it "redirects to the associated IdP SSO target url" do
         do_get
         expect(response).to redirect_to(%r(\Ahttp://idp_sso_url\?SAMLRequest=))
+      end
+
+      it "stores saml_transaction_id in the session" do
+        do_get
+        expect(session[:saml_transaction_id]).to be_present
       end
 
       it "uses the DefaultIdpEntityIdReader" do

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -193,8 +193,8 @@ describe Devise::Strategies::SamlAuthenticatable do
       context "when the session is missing a saml_transaction_id" do
         let(:session) { { } }
 
-        it "uses an empty string for matches_request_id so validation will fail" do
-          expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse], hash_including(matches_request_id: ""))
+        it "uses 'ID_MISSING' for matches_request_id so validation will fail" do
+          expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse], hash_including(matches_request_id: "ID_MISSING"))
           strategy.authenticate!
         end
       end


### PR DESCRIPTION
The `InResponseTo` attribute associates a given assertion to a given authentication request, and according to the [SAML 2.0 CORE specification](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) (section 3.2.2), it's required in any SAML response generated in response to a request. `ruby-saml` [will validate the `InResponseTo` attribute](https://github.com/onelogin/ruby-saml/blob/b55733fd64a559de81ad936b69cd1e9b754c40a8/lib/onelogin/ruby-saml/response.rb#L594-L606) for us if we pass `OneLogin::RubySaml::Response` a non-nil `matches_request_id` parameter when we initialize it.

This PR validates `InResponseTo` headers in SAML responses when the service provider opts-in via configuration. It does so by persisting the ID for the SAML request in the user's session and then sending it along to `ruby-saml` for validation when it receives the SAML response.

closes https://github.com/apokalipto/devise_saml_authenticatable/issues/194