### PR TITLE
Add Ruby 3.0 and 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.1"
+          - "3.0"
           - "2.7"
           - "2.6"
           - "2.5"
@@ -36,6 +38,36 @@ jobs:
             gemfile: Gemfile
             bundler: "2"
           - ruby: "2.4"
+            gemfile: spec/support/Gemfile.rails6
+            bundler: "2"
+          - ruby: "2.5"
+            gemfile: Gemfile
+            bundler: "2"
+          - ruby: "2.6"
+            gemfile: Gemfile
+            bundler: "2"
+          - ruby: "3.0"
+            gemfile: spec/support/Gemfile.rails5
+            bundler: "2"
+          - ruby: "3.0"
+            gemfile: spec/support/Gemfile.rails5.1
+            bundler: "2"
+          - ruby: "3.0"
+            gemfile: spec/support/Gemfile.rails5.2
+            bundler: "2"
+          - ruby: "3.0"
+            gemfile: spec/support/Gemfile.rails6
+            bundler: "2"
+          - ruby: "3.1"
+            gemfile: spec/support/Gemfile.rails5
+            bundler: "2"
+          - ruby: "3.1"
+            gemfile: spec/support/Gemfile.rails5.1
+            bundler: "2"
+          - ruby: "3.1"
+            gemfile: spec/support/Gemfile.rails5.2
+            bundler: "2"
+          - ruby: "3.1"
             gemfile: spec/support/Gemfile.rails6
             bundler: "2"
         include:

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,19 @@ gemspec
 group :test do
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rails', '~> 6.0'
+  gem 'rails', '~> 6.1.0'
   gem 'rspec-rails'
   gem 'sqlite3', '~> 1.4.0'
   gem 'capybara'
   gem 'poltergeist'
+
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.0")
+    gem 'webrick'
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
+    gem 'net-smtp', require: false
+    gem 'net-imap', require: false
+    gem 'net-pop', require: false
+  end
 end

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -224,7 +224,7 @@ describe "SAML Authentication", type: :feature do
   end
 
   def sign_in(entity_id: "")
-    visit "http://localhost:8020/users/saml/sign_in/?entity_id=#{URI.escape(entity_id)}"
+    visit "http://localhost:8020/users/saml/sign_in/?entity_id=#{URI.encode_www_form_component(entity_id)}"
     fill_in "Email", with: "you@example.com"
     fill_in "Password", with: "asdf"
     click_on "Sign in"

--- a/spec/support/Gemfile.rails6
+++ b/spec/support/Gemfile.rails6
@@ -11,4 +11,8 @@ group :test do
   gem 'sqlite3', '~> 1.4.0'
   gem 'capybara'
   gem 'poltergeist'
+
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.0")
+    gem 'webrick'
+  end
 end

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -19,6 +19,12 @@ if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
   gem 'devise', '~> 3.5'
   gem 'nokogiri', '~> 1.6.8'
 end
+
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
+  gem 'net-smtp', require: false
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
+end
   GEMFILE
 }
 

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -27,6 +27,12 @@ if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
 elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.4")
   gem 'responders', '~> 2.4'
 end
+
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
+  gem 'net-smtp', require: false
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
+end
   GEMFILE
 }
 if Rails::VERSION::MAJOR < 6


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to CI and updates the CI Ruby/Rails matrix accordingly. Changes outside of the workflow definition include:

* Adding an explicit gem webrick line to the Gemfile(s) when the Ruby version is 3.0 or greater
* Adding explicit lines for net-smtp, net-imap, and net-pop when the Ruby version is 3.1 or greater to both relevant Gemfiles and the IDP template file.

This PR doesn't include Rails 7, as getting that working properly requires a bit more work with views and UI behavior.