### PR TITLE
Allow proc as value for saml_create_user and saml_update_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,17 @@ In `config/initializers/devise.rb`:
     # ==> Configuration for :saml_authenticatable
 
     # Create user if the user does not exist. (Default is false)
+    # Can also accept a proc, for ex:
+    # Devise.saml_create_user = Proc.new do |model_class, saml_response, auth_value|
+    #  model_class == Admin
+    # end
     config.saml_create_user = true
 
     # Update the attributes of the user after a successful login. (Default is false)
+    # Can also accept a proc, for ex:
+    # Devise.saml_update_user = Proc.new do |model_class, saml_response, auth_value|
+    #  model_class == Admin
+    # end
     config.saml_update_user = true
 
     # Set the default user key. The user will be looked up by this key. Make

--- a/lib/devise_saml_authenticatable.rb
+++ b/lib/devise_saml_authenticatable.rb
@@ -29,10 +29,20 @@ module Devise
   @@saml_logger = true
 
   # Add valid users to database
+  # Can accept a Boolean value or a Proc that is called with the model class, the saml_response and auth_value
+  # Ex: 
+  # Devise.saml_create_user = Proc.new do |model_class, saml_response, auth_value|
+  #  model_class == Admin
+  # end
   mattr_accessor :saml_create_user
   @@saml_create_user = false
 
   # Update user attributes after login
+  # Can accept a Boolean value or a Proc that is called with the model class, the saml_response and auth_value
+  # Ex: 
+  # Devise.saml_update_user = Proc.new do |model_class, saml_response, auth_value|
+  #  model_class == User
+  # end
   mattr_accessor :saml_update_user
   @@saml_update_user = false
 

--- a/lib/devise_saml_authenticatable/model.rb
+++ b/lib/devise_saml_authenticatable/model.rb
@@ -55,8 +55,11 @@ module Devise
             end
           end
 
+          create_user = if Devise.saml_create_user.respond_to?(:call) then Devise.saml_create_user.call(self, decorated_response, auth_value)
+                        else Devise.saml_create_user
+                        end
           if resource.nil?
-            if Devise.saml_create_user
+            if create_user
               logger.info("Creating user(#{auth_value}).")
               resource = new
             else
@@ -65,7 +68,10 @@ module Devise
             end
           end
 
-          if Devise.saml_update_user || (resource.new_record? && Devise.saml_create_user)
+          update_user = if Devise.saml_update_user.respond_to?(:call) then Devise.saml_update_user.call(self, decorated_response, auth_value)
+                        else Devise.saml_update_user
+                        end
+          if update_user || (resource.new_record? && create_user)
             Devise.saml_update_resource_hook.call(resource, decorated_response, auth_value)
           end
 


### PR DESCRIPTION
Solve https://github.com/apokalipto/devise_saml_authenticatable/issues/203.

Sorry for the late PRs. I haven't had any free time lately, and the priority for this feature in our system is not that high.
This PR let `saml_create_user` and `saml_update_user` accept a Proc as value. 
The model class, saml response and auth_value are passed to the proc so that finer-grained decisions can be made.