### PR TITLE
Pass controller request object to idp settings adapter

### DIFF
--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -1,9 +1,9 @@
 require 'ruby-saml'
 module DeviseSamlAuthenticatable
   module SamlConfig
-    def saml_config(idp_entity_id = nil)
+    def saml_config(idp_entity_id = nil, request = nil)
       return file_based_config if file_based_config
-      return adapter_based_config(idp_entity_id) if Devise.idp_settings_adapter
+      return adapter_based_config(idp_entity_id, request) if Devise.idp_settings_adapter
 
       Devise.saml_config
     end
@@ -19,10 +19,16 @@ module DeviseSamlAuthenticatable
       end
     end
 
-    def adapter_based_config(idp_entity_id)
+    def adapter_based_config(idp_entity_id, request)
       config = Marshal.load(Marshal.dump(Devise.saml_config))
 
-      idp_settings_adapter.settings(idp_entity_id).each do |k,v|
+      if idp_settings_adapter.method(:settings).parameters.length == 1
+        settings = idp_settings_adapter.settings(idp_entity_id)
+      else
+        settings = idp_settings_adapter.settings(idp_entity_id, request)
+      end
+
+      settings.each do |k,v|
         acc = "#{k.to_s}=".to_sym
 
         if config.respond_to? acc

--- a/lib/devise_saml_authenticatable/strategy.rb
+++ b/lib/devise_saml_authenticatable/strategy.rb
@@ -65,7 +65,7 @@ module Devise
 
       def response_options
         options = {
-          settings: saml_config(get_idp_entity_id(params)),
+          settings: saml_config(get_idp_entity_id(params), request),
           allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
         }
 

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -102,7 +102,7 @@ describe Devise::SamlSessionsController, type: :controller do
       it 'uses the DefaultIdpEntityIdReader' do
         expect(DeviseSamlAuthenticatable::DefaultIdpEntityIdReader).to receive(:entity_id)
         do_get
-        expect(idp_providers_adapter).to have_received(:settings).with(nil)
+        expect(idp_providers_adapter).to have_received(:settings).with(nil, request)
       end
 
       context 'with a relay_state lambda defined' do
@@ -137,7 +137,7 @@ describe Devise::SamlSessionsController, type: :controller do
 
         it 'redirects to the associated IdP SSO target url' do
           do_get
-          expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com')
+          expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com', request)
           expect(response).to redirect_to(%r{\Ahttp://idp_sso_url\?SAMLRequest=})
         end
       end
@@ -305,7 +305,7 @@ describe Devise::SamlSessionsController, type: :controller do
           it 'redirects to the associated IdP SLO target url' do
             do_delete
             expect(controller).to have_received(:sign_out)
-            expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com')
+            expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com', request)
             expect(response).to redirect_to(%r{\Ahttp://idp_slo_url\?SAMLRequest=})
           end
         end
@@ -385,7 +385,7 @@ describe Devise::SamlSessionsController, type: :controller do
         it 'accepts a LogoutResponse for the associated slo_target_url and redirects to sign_in' do
           do_post
           expect(response.status).to eq 302
-          expect(idp_providers_adapter).to have_received(:settings).with(idp_entity_id)
+          expect(idp_providers_adapter).to have_received(:settings).with(idp_entity_id, request)
           expect(response).to redirect_to 'http://localhost/logout_response'
         end
       end

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -58,7 +58,7 @@ describe Devise::Strategies::SamlAuthenticatable do
         Class.new {
           def self.settings(idp_entity_id, request)
             base = {
-              assertion_consumer_service_url: "#{request.protocol}#{request.host}",
+              assertion_consumer_service_url: "acs url",
               assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
               name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
               issuer: "sp_issuer",
@@ -93,7 +93,7 @@ describe Devise::Strategies::SamlAuthenticatable do
 
       it "authenticates with the response for the corresponding idp" do
         expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse], anything)
-        expect(idp_providers_adapter).to receive(:settings).with(idp_entity_id, request)
+        expect(idp_providers_adapter).to receive(:settings).with(idp_entity_id, anything)
         expect(user_class).to receive(:authenticate_with_saml).with(response, params[:RelayState])
         expect(user).to receive(:after_saml_authentication).with(response.sessionindex)
 

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -56,9 +56,9 @@ describe Devise::Strategies::SamlAuthenticatable do
     context "when saml config uses an idp_adapter" do
       let(:idp_providers_adapter) {
         Class.new {
-          def self.settings(idp_entity_id)
+          def self.settings(idp_entity_id, request)
             base = {
-              assertion_consumer_service_url: "acs_url",
+              assertion_consumer_service_url: "#{request.protocol}#{request.host}",
               assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
               name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
               issuer: "sp_issuer",
@@ -93,7 +93,7 @@ describe Devise::Strategies::SamlAuthenticatable do
 
       it "authenticates with the response for the corresponding idp" do
         expect(OneLogin::RubySaml::Response).to receive(:new).with(params[:SAMLResponse], anything)
-        expect(idp_providers_adapter).to receive(:settings).with(idp_entity_id)
+        expect(idp_providers_adapter).to receive(:settings).with(idp_entity_id, request)
         expect(user_class).to receive(:authenticate_with_saml).with(response, params[:RelayState])
         expect(user).to receive(:after_saml_authentication).with(response.sessionindex)
 


### PR DESCRIPTION
In applications where the domain name can change, the use of the ActionController `request` object is required so the SP url can be set dynamically.

This change makes it so the `request` object can optionally be passed to the `IdPSettingsAdapter#settings` method so urls can be created dynamically.