### PR TITLE
Replace deprecated OneLogin::RubySaml::Settings#issuer with sp_entity_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ In `config/initializers/devise.rb`:
       settings.assertion_consumer_service_url     = "http://localhost:3000/users/saml/auth"
       settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
       settings.name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-      settings.issuer                             = "http://localhost:3000/saml/metadata"
+      settings.sp_entity_id                       = "http://localhost:3000/saml/metadata"
       settings.authn_context                      = ""
       settings.idp_slo_service_url                = "http://localhost/simplesaml/www/saml2/idp/SingleLogoutService.php"
       settings.idp_sso_service_url                = "http://localhost/simplesaml/www/saml2/idp/SSOService.php"
@@ -217,7 +217,7 @@ class IdPSettingsAdapter
         assertion_consumer_service_url: "#{request.protocol}#{request.host_with_port}/users/saml/auth",
         assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
         name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        issuer: "#{request.protocol}#{request.host_with_port}/saml/metadata",
+        sp_entity_id: "#{request.protocol}#{request.host_with_port}/saml/metadata",
         idp_entity_id: "http://www.example_idp_entity_id.com",
         authn_context: "",
         idp_slo_service_url: "http://example_idp_slo_service_url.com",
@@ -229,7 +229,7 @@ class IdPSettingsAdapter
         assertion_consumer_service_url: "http://localhost:3000/users/saml/auth",
         assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
         name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        issuer: "http://localhost:3000/saml/metadata",
+        sp_entity_id: "http://localhost:3000/saml/metadata",
         idp_entity_id: "http://www.another_idp_entity_id.biz",
         authn_context: "",
         idp_slo_service_url: "http://another_idp_slo_service_url.com",

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -40,7 +40,7 @@ describe Devise::SamlSessionsController, type: :controller do
       assertion_consumer_service_url: 'acs_url',
       assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
       name_identifier_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
-      issuer: 'sp_issuer',
+      sp_entity_id: 'sp_issuer',
       idp_entity_id: 'http://www.example.com',
       authn_context: '',
       idp_cert: 'idp_cert'
@@ -167,7 +167,7 @@ describe Devise::SamlSessionsController, type: :controller do
           settings.assertion_consumer_service_url = 'http://localhost:3000/users/saml/auth'
           settings.assertion_consumer_service_binding = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
           settings.name_identifier_format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
-          settings.issuer = 'http://localhost:3000'
+          settings.sp_entity_id = 'http://localhost:3000'
         end
       end
 

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -38,7 +38,7 @@ describe DeviseSamlAuthenticatable::SamlConfig do
                 assertion_consumer_service_url: "acs_url",
                 assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-                issuer: "sp_issuer",
+                sp_entity_id: "sp_issuer",
                 idp_entity_id: "http://www.example.com",
                 authn_context: "",
                 idp_cert: "idp_cert"
@@ -60,7 +60,7 @@ describe DeviseSamlAuthenticatable::SamlConfig do
                 assertion_consumer_service_url: "acs_url_other",
                 assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST_other",
                 name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress_other",
-                issuer: "sp_issuer_other",
+                sp_entity_id: "sp_issuer_other",
                 idp_entity_id: "http://www.example.com_other",
                 authn_context: "_other",
                 idp_cert: "idp_cert_other"
@@ -134,7 +134,7 @@ environment:
   idp_cert_fingerprint: idp_cert_fingerprint
   idp_cert_fingerprint_algorithm: idp_cert_fingerprint_algorithm
   idp_entity_id: idp_entity_id
-  issuer: issuer
+  sp_entity_id: issuer
   name_identifier_format: name_identifier_format
   name_identifier_value: name_identifier_value
   passive: passive
@@ -185,7 +185,7 @@ TARGET_URLS
         expect(saml_config.idp_slo_target_url).to eq('idp_slo_service_url')
         expect(saml_config.idp_sso_target_url).to eq('idp_sso_service_url')
       })
-      expect(saml_config.issuer).to eq('issuer')
+      expect(saml_config.sp_entity_id).to eq('issuer')
       expect(saml_config.name_identifier_format).to eq('name_identifier_format')
       expect(saml_config.name_identifier_value).to eq('name_identifier_value')
       expect(saml_config.passive).to eq('passive')

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -61,7 +61,7 @@ describe Devise::Strategies::SamlAuthenticatable do
               assertion_consumer_service_url: "acs url",
               assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
               name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              issuer: "sp_issuer",
+              sp_entity_id: "sp_issuer",
               idp_entity_id: "http://www.example.com",
               authn_context: "",
               idp_cert: "idp_cert"

--- a/spec/support/idp_settings_adapter.rb.erb
+++ b/spec/support/idp_settings_adapter.rb.erb
@@ -5,7 +5,7 @@ class IdpSettingsAdapter
         assertion_consumer_service_url: "http://localhost:8020/users/saml/auth",
         assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
         name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        issuer: "sp_issuer",
+        sp_entity_id: "sp_issuer",
         idp_entity_id: "http://localhost:8020/saml/metadata",
         authn_context: "",
         idp_cert_fingerprint: "9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D"

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -83,7 +83,7 @@ after_bundle do
 
   config.saml_configure do |settings|
     settings.assertion_consumer_service_url = "http://localhost:8020/users/saml/auth"
-    settings.issuer = "http://localhost:8020/saml/metadata"
+    settings.sp_entity_id = "http://localhost:8020/saml/metadata"
     settings.idp_cert_fingerprint = "9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D"
     settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
   end


### PR DESCRIPTION
The method sp_entity_id was introduced, and issuer deprecated, in ruby-saml version 1.11. References are contained only in docs and test code.

Note that `DefaultIdpEntityIdReader` uses `OneLogin::RubySaml::SloLogoutrequest#issuer`, a distinct and still valid method.