### PR TITLE
Update File.exists? reference

### DIFF
--- a/lib/devise_saml_authenticatable/saml_config.rb
+++ b/lib/devise_saml_authenticatable/saml_config.rb
@@ -14,7 +14,7 @@ module DeviseSamlAuthenticatable
       return @file_based_config if @file_based_config
       idp_config_path = "#{Rails.root}/config/idp.yml"
 
-      if File.exists?(idp_config_path)
+      if File.exist?(idp_config_path)
         @file_based_config ||= OneLogin::RubySaml::Settings.new(YAML.load(File.read(idp_config_path))[Rails.env])
       end
     end

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -156,7 +156,7 @@ TARGET_URLS
     before do
       allow(Rails).to receive(:env).and_return("environment")
       allow(Rails).to receive(:root).and_return("/railsroot")
-      allow(File).to receive(:exists?).with("/railsroot/config/idp.yml").and_return(true)
+      allow(File).to receive(:exist?).with("/railsroot/config/idp.yml").and_return(true)
       allow(File).to receive(:read).with("/railsroot/config/idp.yml").and_return(idp_yaml)
     end
 

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -10,7 +10,7 @@ describe DeviseSamlAuthenticatable::SamlConfig do
   context "when config/idp.yml does not exist" do
     before do
       allow(Rails).to receive(:root).and_return("/railsroot")
-      allow(File).to receive(:exists?).with("/railsroot/config/idp.yml").and_return(false)
+      allow(File).to receive(:exist?).with("/railsroot/config/idp.yml").and_return(false)
     end
 
     it "is the global devise SAML config" do


### PR DESCRIPTION
This should remove the `devise_saml_authenticatable/saml_config.rb:17: warning: File.exists? is deprecated; use File.exist? instead`warnings that are output in tests and server logs