### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"
@@ -38,6 +39,15 @@ jobs:
             bundler: "2"
           - ruby: "3.1"
             gemfile: spec/support/Gemfile.rails6
+            bundler: "2"
+          - ruby: "3.2"
+            gemfile: spec/support/Gemfile.rails5.2
+            bundler: "2"
+          - ruby: "3.2"
+            gemfile: spec/support/Gemfile.rails6
+            bundler: "2"
+          - ruby: "3.2"
+            gemfile: spec/support/Gemfile.rails6.1
             bundler: "2"
     runs-on: ubuntu-latest
     env:

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -139,7 +139,7 @@ describe Devise::Models::SamlAuthenticatable do
 
       it "creates and returns a new user with the name identifier and given attributes" do
         user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
@@ -157,7 +157,7 @@ describe Devise::Models::SamlAuthenticatable do
 
       context "when the proc returns true" do
         it "updates user with given attributes" do
-          expect(Model).to receive(:where).with(email: name_id).and_return([user])
+          expect(Model).to receive(:where).with({ email: name_id }).and_return([user])
           model = Model.authenticate_with_saml(response, nil)
           expect(model.email).to eq('user@example.com')
           expect(model.name).to  eq('A User')
@@ -169,7 +169,7 @@ describe Devise::Models::SamlAuthenticatable do
         let(:name_id) { 'do_not_update@example.com' }
 
         it "does not update user" do
-          expect(Model).to receive(:where).with(email: name_id).and_return([user])
+          expect(Model).to receive(:where).with({ email: name_id }).and_return([user])
           model = Model.authenticate_with_saml(response, nil)
           expect(model.email).to eq('old_mail@mail.com')
           expect(model.name).to  eq('old name')
@@ -185,7 +185,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "creates and returns a new user with the given attributes" do
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
       model = Model.authenticate_with_saml(response, nil)
       expect(model.email).to eq('user@example.com')
       expect(model.name).to  eq('A User')
@@ -204,7 +204,7 @@ describe Devise::Models::SamlAuthenticatable do
       let(:response) { double(:response, issuers: ['to_create_idp'], attributes: attributes, name_id: name_id) }
 
       it "creates and returns a new user with the name identifier and given attributes" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
         model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
@@ -216,7 +216,7 @@ describe Devise::Models::SamlAuthenticatable do
       let(:response) { double(:response, issuers: ['do_not_create_idp'], attributes: attributes, name_id: name_id) }
 
       it "does not creates new user" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
         expect(Model.authenticate_with_saml(response, nil)).to be_nil
       end
     end
@@ -228,13 +228,13 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "returns nil if the user is not found" do
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
       expect(Model.authenticate_with_saml(response, nil)).to be_nil
     end
 
     it "updates the attributes if the user is found" do
       user = Model.new(email: "old_mail@mail.com", name: "old name", new_record: false)
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+      expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
       model = Model.authenticate_with_saml(response, nil)
       expect(model.email).to eq('user@example.com')
       expect(model.name).to  eq('A User')
@@ -254,7 +254,7 @@ describe Devise::Models::SamlAuthenticatable do
       let(:response) { double(:response, issuers: ['to_update_idp'], attributes: attributes, name_id: name_id) }
 
       it "updates user with given attributes" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
@@ -266,7 +266,7 @@ describe Devise::Models::SamlAuthenticatable do
       let(:response) { double(:response, issuers: ['do_not_update_idp'], attributes: attributes, name_id: name_id) }
 
       it "does not update user" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('old_mail@mail.com')
         expect(model.name).to  eq('old name')
@@ -282,7 +282,7 @@ describe Devise::Models::SamlAuthenticatable do
 
       it "looks up the user with a downcased value" do
         user = Model.new(new_record: false)
-        expect(Model).to receive(:where).with(email: 'upper@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'upper@example.com' }).and_return([user])
         expect(Model.authenticate_with_saml(response, nil)).to eq(user)
       end
     end
@@ -320,7 +320,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "returns the user" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         expect(Model.authenticate_with_saml(response, nil)).to eq(user)
       end
     end
@@ -331,7 +331,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "returns nil" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         expect(Model.authenticate_with_saml(response, nil)).to be_nil
       end
     end
@@ -354,7 +354,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "returns the user" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         expect(Model.authenticate_with_saml(response, nil)).to eq(user)
       end
     end
@@ -365,7 +365,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "returns nil" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
         expect(Model.authenticate_with_saml(response, nil)).to be_nil
       end
     end
@@ -412,7 +412,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     def configure_hook(&block)
-      allow(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      allow(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
       allow(Devise).to receive(:saml_default_user_key).and_return(:email)
       allow(Devise).to receive(:saml_create_user).and_return(true)
       allow(Devise).to receive(:saml_update_resource_hook).and_return(block)
@@ -423,7 +423,7 @@ describe Devise::Models::SamlAuthenticatable do
     let(:name_id) { 'SomeUsername' }
 
     it "can replicate the default behaviour for a new user in a custom locator" do
-      allow(Model).to receive(:where).with(email: attributes['saml-email-format']).and_return([])
+      allow(Model).to receive(:where).with({ email: attributes['saml-email-format'] }).and_return([])
 
       configure_hook do |model, saml_response, auth_value|
         Devise.saml_default_resource_locator.call(model, saml_response, auth_value)
@@ -439,7 +439,7 @@ describe Devise::Models::SamlAuthenticatable do
       user = Model.new(email: attributes['saml-email-format'], name: attributes['saml-name-format'])
       user.save!
 
-      allow(Model).to receive(:where).with(email: attributes['saml-email-format']).and_return([user])
+      allow(Model).to receive(:where).with({ email: attributes['saml-email-format'] }).and_return([user])
 
       configure_hook do |model, saml_response, auth_value|
         Devise.saml_default_resource_locator.call(model, saml_response, auth_value)
@@ -453,7 +453,7 @@ describe Devise::Models::SamlAuthenticatable do
     end
 
     it "can change the default behaviour for a new user from the saml response" do
-      allow(Model).to receive(:where).with(foo: attributes['saml-email-format'], bar: name_id).and_return([])
+      allow(Model).to receive(:where).with({ foo: attributes['saml-email-format'], bar: name_id }).and_return([])
 
       configure_hook do |model, saml_response, auth_value|
         name_id = saml_response.raw_response.name_id
@@ -470,7 +470,7 @@ describe Devise::Models::SamlAuthenticatable do
       user = Model.new(email: attributes['saml-email-format'], name: attributes['saml-name-format'])
       user.save!
 
-      allow(Model).to receive(:where).with(foo: attributes['saml-email-format'], bar: name_id).and_return([user])
+      allow(Model).to receive(:where).with({ foo: attributes['saml-email-format'], bar: name_id }).and_return([user])
 
       configure_hook do |model, saml_response, auth_value|
         name_id = saml_response.raw_response.name_id

--- a/spec/devise_saml_authenticatable/model_spec.rb
+++ b/spec/devise_saml_authenticatable/model_spec.rb
@@ -64,12 +64,12 @@ describe Devise::Models::SamlAuthenticatable do
 
   it "looks up the user by the configured default user key" do
     user = Model.new(new_record: false)
-    expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+    expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
     expect(Model.authenticate_with_saml(response, nil)).to eq(user)
   end
 
   it "returns nil if it cannot find a user" do
-    expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+    expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
     expect(Model.authenticate_with_saml(response, nil)).to be_nil
   end
 
@@ -83,12 +83,12 @@ describe Devise::Models::SamlAuthenticatable do
 
     it "looks up the user by the configured default user key" do
       user = Model.new(new_record: false)
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([user])
+      expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([user])
       expect(Model.authenticate_with_saml(response, nil)).to eq(user)
     end
 
     it "returns nil if it cannot find a user" do
-      expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+      expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
       expect(Model.authenticate_with_saml(response, nil)).to be_nil
     end
 
@@ -98,7 +98,7 @@ describe Devise::Models::SamlAuthenticatable do
       end
 
       it "creates and returns a new user with the name identifier and given attributes" do
-        expect(Model).to receive(:where).with(email: 'user@example.com').and_return([])
+        expect(Model).to receive(:where).with({ email: 'user@example.com' }).and_return([])
         model = Model.authenticate_with_saml(response, nil)
         expect(model.email).to eq('user@example.com')
         expect(model.name).to  eq('A User')
@@ -114,7 +114,7 @@ describe Devise::Models::SamlAuthenticatable do
 
       context "when the proc returns true" do
         it "creates and returns a new user with the name identifier and given attributes" do
-          expect(Model).to receive(:where).with(email: name_id).and_return([])
+          expect(Model).to receive(:where).with({ email: name_id }).and_return([])
           model = Model.authenticate_with_saml(response, nil)
           expect(model.email).to eq('user@example.com')
           expect(model.name).to  eq('A User')
@@ -126,7 +126,7 @@ describe Devise::Models::SamlAuthenticatable do
         let(:name_id) { 'do_not_create@example.com' }
 
         it "does not creates new user" do
-          expect(Model).to receive(:where).with(email: name_id).and_return([])
+          expect(Model).to receive(:where).with({ email: name_id }).and_return([])
           expect(Model.authenticate_with_saml(response, nil)).to be_nil
         end
       end


### PR DESCRIPTION
To get the specs to pass I had to add explicit hashes to the `with` clauses, so they would be properly disambiguated from keyword arguments.

This runs green on my fork.