### PR TITLE
Adjust test setup to use OneLogin::RubySaml::Attributes

### DIFF
--- a/spec/devise_saml_authenticatable/saml_mapped_attributes_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_mapped_attributes_spec.rb
@@ -14,11 +14,20 @@ describe SamlAuthenticatable::SamlMappedAttributes do
   end
 
   describe "#value_by_resource_key" do
+    before do
+      @single_value_compatibility = OneLogin::RubySaml::Attributes.single_value_compatibility
+      OneLogin::RubySaml::Attributes.single_value_compatibility = false
+    end
+
+    after do
+      OneLogin::RubySaml::Attributes.single_value_compatibility = @single_value_compatibility
+    end
+
     RSpec.shared_examples "correctly maps the value of the resource key" do |saml_key, resource_key, expected_value|
       subject(:perform) { instance.value_by_resource_key(resource_key) }
 
       it "correctly maps the resource key, #{resource_key}, to the value of the '#{saml_key}' SAML key" do
-        saml_attributes[saml_key] = saml_attributes.delete(resource_key)
+        saml_attributes[saml_key] = saml_attributes.to_h.delete(resource_key)
         expect(perform).to eq(expected_value)
       end
     end

--- a/spec/devise_saml_authenticatable/saml_mapped_attributes_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_mapped_attributes_spec.rb
@@ -6,11 +6,11 @@ describe SamlAuthenticatable::SamlMappedAttributes do
   let(:attribute_map_file) { File.join(File.dirname(__FILE__), '../support/attribute-map.yml') }
   let(:attribute_map) { YAML.load(File.read(attribute_map_file)) }
   let(:saml_attributes) do
-    {
+    OneLogin::RubySaml::Attributes.new({
       "first_name" => ["John"],
       "last_name"=>["Smith"],
       "email"=>["john.smith@example.com"]
-    }
+    })
   end
 
   describe "#value_by_resource_key" do


### PR DESCRIPTION
Split from https://github.com/apokalipto/devise_saml_authenticatable/pull/245

Here I changed the test setup so that we'd get the expected results, rather than relying on global state from the saml gem and changing the test results.