### PR TITLE
Exclude combinations of ruby2.7 and Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           - ruby: "2.6"
             gemfile: Gemfile
             bundler: "2"
+          - ruby: "2.7"
+            gemfile: Gemfile
+            bundler: "2"
           - ruby: "3.0"
             gemfile: spec/support/Gemfile.rails5.2
             bundler: "2"


### PR DESCRIPTION
I noticed that running [test (2.7, Gemfile, 2)](https://github.com/apokalipto/devise_saml_authenticatable/actions/runs/7941416410/job/21683746313?pr=249)  fails.

Support for sqlite3-ruby in ruby 2.7 has ended.
https://github.com/sparklemotion/sqlite3-ruby/blob/main/CHANGELOG.md#170--2023-12-27
As a result, `bundle install` now fails.

Exclude tests for ruby 2.7 and Gemfile.
