### PR TITLE
Update build matrix for EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,46 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
-          - "2.7"
-          - "2.6"
         gemfile:
           - Gemfile
           - spec/support/Gemfile.rails6.1
-          - spec/support/Gemfile.rails6
-          - spec/support/Gemfile.rails5.2
+          - spec/support/Gemfile.rails7
         bundler:
           - "2"
-        exclude:
-          - ruby: "2.6"
-            gemfile: Gemfile
-            bundler: "2"
-          - ruby: "3.0"
-            gemfile: spec/support/Gemfile.rails5.2
-            bundler: "2"
-          - ruby: "3.0"
-            gemfile: spec/support/Gemfile.rails6
-            bundler: "2"
-          - ruby: "3.1"
-            gemfile: spec/support/Gemfile.rails5.2
-            bundler: "2"
-          - ruby: "3.1"
-            gemfile: spec/support/Gemfile.rails6
-            bundler: "2"
-          - ruby: "3.2"
-            gemfile: spec/support/Gemfile.rails5.2
-            bundler: "2"
-          - ruby: "3.2"
-            gemfile: spec/support/Gemfile.rails6
-            bundler: "2"
-          - ruby: "3.2"
-            gemfile: spec/support/Gemfile.rails6.1
-            bundler: "2"
-          - ruby: "3.2"
-            gemfile: spec/support/Gemfile.rails7
-            bundler: "2"
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}


### PR DESCRIPTION
Remove old Rubies and Rails, and add the latest Ruby

Rails maintenance policy: https://guides.rubyonrails.org/maintenance_policy.html
Ruby stable releases: https://www.ruby-lang.org/en/downloads/