### PR TITLE
Bump ruby-saml to v1.17.0 to fix CVE-2024-4540

### DIFF
--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.6.0"
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","~> 1.7")
+  gem.add_dependency("ruby-saml","~> 1.17")
 end


### PR DESCRIPTION
Hello everyone 👋 

The following security vulnerability was recently discovered [CVE-2024-4540](https://www.cve.org/CVERecord?id=CVE-2024-4540)

A new version of ruby-saml, containing a fix for this bug, was released a couple of days ago: [changelog](https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.17.0)

This PR bumps the ruby-saml dependency to the [version](https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.17.0) that contains the fix.

Please let me know if you need more informations...

Thank you!
