### PR TITLE
Test fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem 'rspec', '~> 3.0'
   gem 'rails', '~> 7.1.0'
   gem 'rspec-rails'
-  gem 'sqlite3', '~> 1.4.0'
+  gem 'sqlite3', '~> 1.4'
   gem 'capybara'
   gem 'selenium-webdriver'
 

--- a/spec/controllers/devise/saml_sessions_controller_spec.rb
+++ b/spec/controllers/devise/saml_sessions_controller_spec.rb
@@ -41,7 +41,7 @@ describe Devise::SamlSessionsController, type: :controller do
       assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
       name_identifier_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
       sp_entity_id: 'sp_issuer',
-      idp_entity_id: 'http://www.example.com',
+      idp_entity_id: 'https://www.example.com',
       authn_context: '',
       idp_cert: 'idp_cert'
     }
@@ -123,7 +123,7 @@ describe Devise::SamlSessionsController, type: :controller do
         end
 
         subject(:do_get) do
-          get :new, params: { entity_id: 'http://www.example.com' }
+          get :new, params: { entity_id: 'https://www.example.com' }
         end
 
         before do
@@ -137,7 +137,7 @@ describe Devise::SamlSessionsController, type: :controller do
 
         it 'redirects to the associated IdP SSO target url' do
           do_get
-          expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com', request)
+          expect(idp_providers_adapter).to have_received(:settings).with('https://www.example.com', request)
           expect(response).to redirect_to(%r{\Ahttp://idp_sso_url\?SAMLRequest=})
         end
       end
@@ -290,7 +290,7 @@ describe Devise::SamlSessionsController, type: :controller do
           end
 
           subject(:do_delete) do
-            delete :destroy, params: { entity_id: 'http://www.example.com' }
+            delete :destroy, params: { entity_id: 'https://www.example.com' }
           end
 
           before do
@@ -305,7 +305,7 @@ describe Devise::SamlSessionsController, type: :controller do
           it 'redirects to the associated IdP SLO target url' do
             do_delete
             expect(controller).to have_received(:sign_out)
-            expect(idp_providers_adapter).to have_received(:settings).with('http://www.example.com', request)
+            expect(idp_providers_adapter).to have_received(:settings).with('https://www.example.com', request)
             expect(response).to redirect_to(%r{\Ahttp://idp_slo_url\?SAMLRequest=})
           end
         end
@@ -361,7 +361,7 @@ describe Devise::SamlSessionsController, type: :controller do
         double(:slo_logoutrequest, {
                  id: 42,
                  name_id: name_id,
-                 issuer: 'http://www.example.com'
+                 issuer: 'https://www.example.com'
                })
       end
       let(:name_id) { '12312312' }
@@ -377,7 +377,7 @@ describe Devise::SamlSessionsController, type: :controller do
       end
 
       context 'with a specified idp' do
-        let(:idp_entity_id) { 'http://www.example.com' }
+        let(:idp_entity_id) { 'https://www.example.com' }
         before do
           Devise.idp_settings_adapter = idp_providers_adapter
         end

--- a/spec/devise_saml_authenticatable/saml_config_spec.rb
+++ b/spec/devise_saml_authenticatable/saml_config_spec.rb
@@ -33,13 +33,13 @@ describe DeviseSamlAuthenticatable::SamlConfig do
 
           def self.settings(idp_entity_id)
             #some hash of stuff (by doing a fetch, in our case, but could also be a giant hash keyed by idp_entity_id)
-            if idp_entity_id == "http://www.example.com"
+            if idp_entity_id == "https://www.example.com"
               base = {
                 assertion_consumer_service_url: "acs_url",
                 assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
                 sp_entity_id: "sp_issuer",
-                idp_entity_id: "http://www.example.com",
+                idp_entity_id: "https://www.example.com",
                 authn_context: "",
                 idp_cert: "idp_cert"
               }
@@ -55,13 +55,13 @@ describe DeviseSamlAuthenticatable::SamlConfig do
                 )
               })
               base
-            elsif idp_entity_id == "http://www.example.com_other"
+            elsif idp_entity_id == "https://www.example.com_other"
               base = {
                 assertion_consumer_service_url: "acs_url_other",
                 assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST_other",
                 name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress_other",
                 sp_entity_id: "sp_issuer_other",
-                idp_entity_id: "http://www.example.com_other",
+                idp_entity_id: "https://www.example.com_other",
                 authn_context: "_other",
                 idp_cert: "idp_cert_other"
               }
@@ -85,7 +85,7 @@ describe DeviseSamlAuthenticatable::SamlConfig do
       }
 
       context "when a specific idp_entity_id is requested" do
-        let(:idp_entity_id) { "http://www.example.com" }
+        let(:idp_entity_id) { "https://www.example.com" }
         it "uses the settings from the adapter for that idp" do
           expect(saml_config.idp_entity_id).to eq (idp_entity_id)
           with_ruby_saml_1_12_or_greater(proc {
@@ -98,7 +98,7 @@ describe DeviseSamlAuthenticatable::SamlConfig do
       end
 
       context "when another idp_entity_id is requested" do
-        let(:idp_entity_id) { "http://www.example.com_other" }
+        let(:idp_entity_id) { "https://www.example.com_other" }
         it "returns the other idp settings" do
           expect(saml_config.idp_entity_id).to eq (idp_entity_id)
           with_ruby_saml_1_12_or_greater(proc {

--- a/spec/devise_saml_authenticatable/strategy_spec.rb
+++ b/spec/devise_saml_authenticatable/strategy_spec.rb
@@ -62,7 +62,7 @@ describe Devise::Strategies::SamlAuthenticatable do
               assertion_consumer_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
               name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
               sp_entity_id: "sp_issuer",
-              idp_entity_id: "http://www.example.com",
+              idp_entity_id: "https://www.example.com",
               authn_context: "",
               idp_cert: "idp_cert"
             }

--- a/spec/features/saml_authentication_spec.rb
+++ b/spec/features/saml_authentication_spec.rb
@@ -202,7 +202,7 @@ describe "SAML Authentication", type: :feature do
         fill_in "Password", with: "asdf"
         click_on "Sign in"
         expect(page).to have_content(:all, "Example Domain This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.")
-        expect(current_url).to eq("http://www.example.com/")
+        expect(current_url).to eq("https://www.example.com/")
       end
     end
   end

--- a/spec/support/idp_template.rb
+++ b/spec/support/idp_template.rb
@@ -6,7 +6,6 @@
 @valid_destination = ENV.fetch('VALID_DESTINATION', "true")
 
 gem 'stub_saml_idp'
-gem 'thin'
 
 if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
   gem 'net-smtp', require: false

--- a/spec/support/saml_idp_controller.rb.erb
+++ b/spec/support/saml_idp_controller.rb.erb
@@ -45,7 +45,7 @@ class SamlIdpController < StubSamlIdp::IdpController
     now = Time.now.utc
     response_id = SecureRandom.uuid
     audience_uri = opts[:audience_uri] || "#{saml_acs_url[/^(.*?\/\/.*?\/)/, 1]}saml/metadata"
-    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
+    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "https://example.com"
 
     attributes = opts.fetch(:attributes, {})
     if attributes.any?
@@ -96,7 +96,7 @@ class SamlIdpController < StubSamlIdp::IdpController
     if Idp::Application.config.slo_sp_url
       redirect_to "#{Idp::Application.config.slo_sp_url}?SAMLResponse=#{@saml_slo_response}"
     else
-      redirect_to 'http://example.com'
+      redirect_to 'https://example.com'
     end
   end
 
@@ -148,7 +148,7 @@ class SamlIdpController < StubSamlIdp::IdpController
     now = Time.now.utc
     response_id = SecureRandom.uuid
     audience_uri = opts[:audience_uri] || (@saml_slo_acs_url && @saml_slo_acs_url[/^(.*?\/\/.*?\/)/, 1])
-    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
+    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "https://example.com"
 
     assertion = %[<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{session_index}" IssueInstant="#{now.iso8601}" Version="2.0"><Issuer2>#{issuer_uri}</Issuer2><Subject><NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">#{nameID}</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="#{@saml_slo_request_id}" NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_slo_acs_url}"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><AudienceRestriction><Audience>#{audience_uri}</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="#{email_address_attribute_key}"><AttributeValue>#{nameID}</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{session_index}"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>]
 
@@ -183,7 +183,7 @@ class SamlIdpController < StubSamlIdp::IdpController
   def encode_SAML_SLO_Request(nameID, opts = {})
     now = Time.now.utc
     response_id = SecureRandom.uuid
-    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "http://example.com"
+    issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url.split("?")[0]) || "https://example.com"
     xml = %[<samlp:LogoutRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/spec/support/sp_template.rb
+++ b/spec/support/sp_template.rb
@@ -12,7 +12,6 @@ ruby_saml_version = ENV.fetch("RUBY_SAML_VERSION")
 
 gem 'devise_saml_authenticatable', path: File.expand_path("../../..", __FILE__)
 gem 'ruby-saml', ruby_saml_version
-gem 'thin'
 
 if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
   gem 'net-smtp', require: false
@@ -22,7 +21,10 @@ end
 
 if Rails::VERSION::MAJOR < 6
   # sqlite3 is hard-coded in Rails < 6 to v1.3.x
-  gsub_file 'Gemfile', /^gem 'sqlite3'.*$/, "gem 'sqlite3', '~> 1.3.6'"
+  gsub_file 'Gemfile', /^gem ['"]sqlite3['"].*$/, 'gem "sqlite3", "~> 1.3.6"'
+elsif Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("3.1")
+  # sqlite3 2.1 does not support Ruby 3.0
+  gsub_file 'Gemfile', /^gem ['"]sqlite3['"].*$/, 'gem "sqlite3", "~> 1.4"'
 end
 
 template File.expand_path('../attribute_map_resolver.rb.erb', __FILE__), 'app/lib/attribute_map_resolver.rb'
@@ -40,7 +42,7 @@ create_file('app/lib/our_saml_failed_callback_handler.rb', <<-CALLBACKHANDLER)
 
 class OurSamlFailedCallbackHandler
   def handle(response, strategy)
-    strategy.redirect! "http://www.example.com"
+    strategy.redirect! "https://www.example.com"
   end
 end
 CALLBACKHANDLER


### PR DESCRIPTION
- Remove thin, we don't need it anymore and it adds an eventmachine dependency
- Something is enforcing HTTPS, so accept it and update configuration
- Loosen sqlite version restriction, due to [this issue](https://github.com/sparklemotion/sqlite3-ruby/issues/519#issuecomment-2020781375)