### PR TITLE
Fix prepend_before_action order on SamlSessionsController

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -4,7 +4,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
 
   skip_before_action :verify_authenticity_token, raise: false
-  prepend_before_action :verify_signed_out_user, :store_info_for_sp_initiated_logout, only: :destroy
+  prepend_before_action :store_info_for_sp_initiated_logout, :verify_signed_out_user, only: :destroy
 
   def new
     idp_entity_id = get_idp_entity_id(params)


### PR DESCRIPTION
Fixes issue 219: https://github.com/apokalipto/devise_saml_authenticatable/issues/219

The names in `prepend_before_action` do have the wrong order. The last one gets called first. If `store_info_for_sp_initiated_logout` gets called before `verify_signed_out_user`, this lead to the issuer that `current_user` is nil. 