### PR TITLE
bumped ruby-saml to 1.8

### DIFF
--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.6.0"
 
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml","~> 1.17")
+  gem.add_dependency("ruby-saml","~> 1.18")
 end


### PR DESCRIPTION
Hey everyone! There was a [vulnerability found](https://nvd.nist.gov/vuln/detail/CVE-2025-25292) in ruby-saml, 1.7.0.

The dependency version needs to be bumped to 1.18. `gem.add_dependency("ruby-saml","~> 1.18")`

I reported it earlier in https://github.com/apokalipto/devise_saml_authenticatable/issues/261, but figured I could just fork and fix it really quick. 

Cheers!